### PR TITLE
Handle negative indices in GameZone.removeAt

### DIFF
--- a/lib/engine/types.dart
+++ b/lib/engine/types.dart
@@ -122,7 +122,7 @@ class GameZone {
   void add(CardInstance card) => cards.add(card);
   void addAll(List<CardInstance> newCards) => cards.addAll(newCards);
   bool remove(CardInstance card) => cards.remove(card);
-  CardInstance? removeAt(int index) => index < cards.length ? cards.removeAt(index) : null;
+  CardInstance? removeAt(int index) => index >= 0 && index < cards.length ? cards.removeAt(index) : null;
   void insert(int index, CardInstance card) => cards.insert(index, card);
   void clear() => cards.clear();
 

--- a/test/engine_test.dart
+++ b/test/engine_test.dart
@@ -12,7 +12,7 @@ void main() {
       final field1 = Card(
         id: 'field1',
         name: 'Field 1',
-        type: CardType.field,
+        type: CardType.domain,
         abilities: [
           Ability(
             when: TriggerWhen.onPlay,
@@ -28,7 +28,7 @@ void main() {
       final field2 = Card(
         id: 'field2',
         name: 'Field 2',
-        type: CardType.field,
+        type: CardType.domain,
         abilities: [
           Ability(
             when: TriggerWhen.onPlay,
@@ -54,17 +54,17 @@ void main() {
         ));
       }
 
-      FieldRule.playField(state, instance1);
+      FieldRule.playDomain(state, instance1);
       TriggerStack.resolveAll(state);
 
       expect(state.hand.count, 1);
-      expect(state.field.first?.card.id, 'field1');
+      expect(state.domain.first?.card.id, 'field1');
 
-      FieldRule.playField(state, instance2);
+      FieldRule.playDomain(state, instance2);
       final logs = TriggerStack.resolveAll(state).logs;
 
       expect(state.hand.count, 6);
-      expect(state.field.first?.card.id, 'field2');
+      expect(state.domain.first?.card.id, 'field2');
       expect(state.grave.count, 1);
       
       expect(logs.any((log) => log.contains('Field 2')), true);

--- a/test/game_zone_test.dart
+++ b/test/game_zone_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../lib/engine/types.dart';
+
+void main() {
+  group('GameZone', () {
+    test('removeAt returns null for negative index', () {
+      final zone = GameZone(type: Zone.hand);
+      zone.add(CardInstance(
+        card: Card(id: 'c1', name: 'C1', type: CardType.spell),
+        instanceId: '1',
+      ));
+
+      final removed = zone.removeAt(-1);
+
+      expect(removed, isNull);
+      expect(zone.count, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- prevent negative indexes from causing exceptions when removing cards from GameZone
- update engine tests for domain cards and add test coverage for negative index removal

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689880631cd88330bc770216b5ee2456