### PR TITLE
docs: improve engine comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # solitcg
+
+SoliTCG は Dart/Flutter 製の実験的なカードゲームエンジンです。
+YAML で定義されたカードデータを読み込み、シンプルなゲームロジックを実装しています。
+現在は 1 ターン完結のデモが動作しており、基本的なプレイと効果解決を試せます。
+
+## Getting Started
+
+1. Flutter 3.x と Dart の開発環境を用意します。
+2. 依存パッケージを取得します。
+
+   ```bash
+   flutter pub get
+   ```
+
+3. Web デモを起動します。
+
+   ```bash
+   flutter run -d chrome
+   ```
+
+## Tests
+
+ユニットテストは次のコマンドで実行できます。
+
+```bash
+dart test
+```
+
+## Documentation
+
+詳細な仕様は `docs` ディレクトリを参照してください。
+
+- `CARD_YAML_SPEC.md` — カード定義の YAML 仕様
+- `GAME_RULES.md` — 基本的なルール概要

--- a/lib/engine/loader.dart
+++ b/lib/engine/loader.dart
@@ -3,6 +3,7 @@ import 'package:yaml/yaml.dart';
 import 'package:flutter/services.dart';
 import 'types.dart';
 
+/// YAML 形式のカードデータを読み込むヘルパークラス。
 class CardLoader {
   static CardType? _parseCardType(String? value) {
     if (value == null) return null;
@@ -126,6 +127,7 @@ class CardLoader {
     return abilities;
   }
 
+  /// YAML 文字列から [Card] を生成する。
   static Card? parseCard(String yamlContent) {
     try {
       final doc = loadYaml(yamlContent);
@@ -168,6 +170,7 @@ class CardLoader {
     }
   }
 
+  /// アセットからカード YAML を読み込み [Card] に変換する。
   static Future<Card?> loadCardFromAsset(String assetPath) async {
     try {
       final yamlContent = await rootBundle.loadString(assetPath);
@@ -177,6 +180,7 @@ class CardLoader {
     }
   }
 
+  /// index.yaml からカードファイル一覧を取得する。
   static Future<List<String>> loadCardIndex() async {
     try {
       final yamlContent = await rootBundle.loadString('assets/cards/index.yaml');
@@ -190,23 +194,25 @@ class CardLoader {
     }
   }
 
+  /// すべてのカードファイルを読み込み [Card] のリストを返す。
   static Future<List<Card>> loadAllCards() async {
     final cardFiles = await loadCardIndex();
     final cards = <Card>[];
-    
+
     for (final cardFile in cardFiles) {
       final card = await loadCardFromAsset('assets/cards/$cardFile');
       if (card != null) {
         cards.add(card);
       }
     }
-    
+
     return cards;
   }
 
+  /// カードデータが基本的な要件を満たしているか検証する。
   static bool validateCard(Card card) {
     if (card.id.isEmpty || card.name.isEmpty) return false;
-    
+
     switch (card.type) {
       case CardType.monster:
       case CardType.ritual:
@@ -220,13 +226,13 @@ class CardLoader {
       default:
         break;
     }
-    
+
     for (final ability in card.abilities) {
       for (final effect in ability.effects) {
         if (effect.op.isEmpty) return false;
       }
     }
-    
+
     return true;
   }
 }

--- a/lib/engine/stack.dart
+++ b/lib/engine/stack.dart
@@ -2,12 +2,15 @@ import 'dart:collection';
 import 'types.dart';
 import 'ops.dart';
 
+/// トリガーキューを管理し、効果解決を行うユーティリティ。
 class TriggerStack {
+  /// トリガーをキューに追加し、ログを記録する。
   static void enqueueTrigger(GameState state, Trigger trigger) {
     state.triggerQueue.addLast(trigger);
     state.addToLog('Triggered: ${trigger.source.card.name} - ${_triggerWhenToString(trigger.ability.when)}');
   }
 
+  /// アビリティからトリガーを生成しキューに追加する。
   static void enqueueAbility(GameState state, CardInstance source, Ability ability, {Map<String, dynamic>? context}) {
     final trigger = Trigger(
       id: 'trigger_${DateTime.now().millisecondsSinceEpoch}',
@@ -19,6 +22,8 @@ class TriggerStack {
     enqueueTrigger(state, trigger);
   }
 
+  /// キュー内のトリガーを順に解決する。
+  /// ループ防止のため最大100回まで実行する。
   static GameResult resolveAll(GameState state) {
     final logs = <String>[];
     int iterations = 0;
@@ -49,6 +54,7 @@ class TriggerStack {
     return GameResult.success(logs: logs);
   }
 
+  /// 単一のトリガーを解決する。
   static GameResult _resolveTrigger(GameState state, Trigger trigger) {
     final logs = <String>[];
     
@@ -86,6 +92,7 @@ class TriggerStack {
     return GameResult.success(logs: logs);
   }
 
+  /// TriggerWhen をログ用の文字列に変換する。
   static String _triggerWhenToString(TriggerWhen when) {
     switch (when) {
       case TriggerWhen.onPlay:
@@ -104,7 +111,9 @@ class TriggerStack {
   }
 }
 
+/// 文字列表現を評価して true/false を返す簡易式評価機。
 class ExpressionEvaluator {
+  /// 与えられた式を評価する。解析に失敗した場合は false を返す。
   static bool evaluate(GameState state, String expression) {
     try {
       return _parseExpression(state, expression.trim());
@@ -113,6 +122,7 @@ class ExpressionEvaluator {
     }
   }
 
+  /// シンプルな比較式を解析して評価する。
   static bool _parseExpression(GameState state, String expr) {
     if (expr.contains('>=')) {
       final parts = expr.split('>=').map((e) => e.trim()).toList();
@@ -205,6 +215,7 @@ class ExpressionEvaluator {
     }
   }
 
+  /// 文字列の前後にあるクォートを取り除く。
   static String _removeQuotes(String text) {
     if ((text.startsWith("'") && text.endsWith("'")) || 
         (text.startsWith('"') && text.endsWith('"'))) {
@@ -213,6 +224,7 @@ class ExpressionEvaluator {
     return text;
   }
   
+  /// count(type:'artifact', zone:'board:self') のような形式の式を評価する。
   static int _evaluateCountExpression(GameState state, String expr) {
     // count(type:'artifact', zone:'board:self') のような形式を処理
     try {

--- a/lib/engine/types.dart
+++ b/lib/engine/types.dart
@@ -1,11 +1,15 @@
 import 'dart:collection';
 
+/// カードの種類。
 enum CardType { monster, ritual, spell, arcane, artifact, relic, equip, domain }
 
+/// アビリティの発動タイミング。
 enum TriggerWhen { onPlay, onDestroy, activated, static, onDraw, onDiscard }
 
+/// ゲーム内でカードが存在する領域。
 enum Zone { hand, deck, board, domain, grave, extra }
 
+/// 攻撃力・防御力・HP を保持するステータス。
 class Stats {
   final int atk;
   final int def;
@@ -22,18 +26,21 @@ class Stats {
   }
 }
 
+/// 装備カードの設定。
 class EquipConfig {
   final List<String> validTargets;
 
   const EquipConfig({required this.validTargets});
 }
 
+/// ドメインカードの設定。
 class DomainConfig {
   final bool unique;
 
   const DomainConfig({this.unique = true});
 }
 
+/// 効果の1ステップを表すデータ。
 class EffectStep {
   final String op;
   final Map<String, dynamic> params;
@@ -41,6 +48,7 @@ class EffectStep {
   const EffectStep({required this.op, required this.params});
 }
 
+/// カードが持つアビリティ。
 class Ability {
   final TriggerWhen when;
   final List<String>? pre;
@@ -55,6 +63,7 @@ class Ability {
   });
 }
 
+/// YAML から読み込まれるカードデータ。
 class Card {
   final String id;
   final String name;
@@ -81,6 +90,7 @@ class Card {
   });
 }
 
+/// フィールド上に存在するカードのインスタンス。
 class CardInstance {
   final Card card;
   final String instanceId;
@@ -97,6 +107,7 @@ class CardInstance {
   Stats get stats => currentStats ?? card.stats ?? const Stats(atk: 0, def: 0, hp: 0);
 }
 
+/// キューに積まれるトリガー情報。
 class Trigger {
   final String id;
   final CardInstance source;
@@ -113,6 +124,7 @@ class Trigger {
   });
 }
 
+/// 各ゾーン（手札・デッキ等）を表すコンテナ。
 class GameZone {
   final Zone type;
   final List<CardInstance> cards;
@@ -143,6 +155,7 @@ class GameZone {
   }
 }
 
+/// ゲーム全体の状態を保持する。
 class GameState {
   final GameZone hand;
   final GameZone deck;
@@ -202,6 +215,7 @@ class GameState {
   bool get hasDomain => domain.isNotEmpty;
 }
 
+/// 効果解決や処理の結果を表す。
 class GameResult {
   final bool success;
   final String? error;


### PR DESCRIPTION
## Summary
- document card loader and trigger stack behavior
- add doc comments for core engine types
- clarify README with demo status and Flutter 3.x requirement

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898a668094c83308b3232985f16bca0