### PR TITLE
feat: カード画像・2タップ選択・ビジュアルポリッシュ

### DIFF
--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -76,3 +76,10 @@
 - **理由**: AI エージェントが設計意図を正確に把握し、一貫した開発スタイルを維持するため
 - **影響範囲**: `docs/` 全体、`CLAUDE.md`、`README.md`
 - **ADR**: なし（ドキュメント整備のため）
+
+## 2026-04-08 00:00 - [UI] カード画像・選択システム・ビジュアルポリッシュ
+
+- **判断内容**: (1) CardData に `String? image` フィールドを追加し YAML から読み込む。(2) 2タップ選択モデルを実装（1回目=選択+詳細パネル表示、2回目=プレイ/発動）。(3) 全体的な UI ポリッシュ（グラデーションカード・ゾーン背景・HUD・ログパネル）。
+- **理由**: カードビジュアルの貧弱さとタップ即プレイの UX 問題を解消し、TCG らしいカッコいい画面を実現するため。
+- **影響範囲**: `lib/domain/models/card_data.dart`, `lib/domain/models/card_selection_state.dart`（新規）, `lib/core/game_state.dart`, `lib/presentation/components/card_component.dart`, `lib/presentation/components/board_component.dart`, `lib/ui/screens/game_screen.dart`, `lib/ui/theme/game_theme.dart`（新規）, `lib/ui/widgets/card_detail_panel.dart`（新規）, `pubspec.yaml`
+- **ADR**: なし（UI 改善のため）

--- a/lib/core/game_state.dart
+++ b/lib/core/game_state.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
+import '../domain/models/card_selection_state.dart';
 import '../domain/models/choice_request.dart';
 import '../domain/models/trigger.dart';
 import '../domain/models/game_zone.dart';
@@ -28,6 +29,14 @@ class GameState {
   final List<String> actionLog = [];
 
   final ValueNotifier<ChoiceRequest?> choiceRequest = ValueNotifier(null);
+
+  /// 現在選択中のカード状態。Flutter UI の詳細パネル表示に使用する。
+  final ValueNotifier<CardSelectionState?> selectedCard = ValueNotifier(null);
+
+  /// カードの選択状態を更新する。null を渡すと選択解除。
+  void selectCard(CardSelectionState? selection) {
+    selectedCard.value = selection;
+  }
 
   int _nextInstanceId = 1;
   int _triggerOrder = 0;

--- a/lib/data/repositories/card_repository.dart
+++ b/lib/data/repositories/card_repository.dart
@@ -146,6 +146,7 @@ class CardRepository {
       final equip = _parseEquipConfig(doc['equip']);
       final domain = _parseDomainConfig(doc['domain']);
       final abilities = _parseAbilities(doc['abilities']);
+      final image = doc['image'] as String?;
 
       return CardData(
         id: id,
@@ -158,6 +159,7 @@ class CardRepository {
         equip: equip,
         domain: domain,
         abilities: abilities,
+        image: image,
       );
     } catch (e) {
       return null;

--- a/lib/domain/models/card_data.dart
+++ b/lib/domain/models/card_data.dart
@@ -72,6 +72,10 @@ class CardData {
   final DomainConfig? domain;
   final List<Ability> abilities;
 
+  /// カード画像のファイル名（例: "mon_warrior.png"）。
+  /// assets/images/cards/ 以下に配置。null の場合は色付き矩形で代替表示。
+  final String? image;
+
   const CardData({
     required this.id,
     required this.name,
@@ -83,5 +87,6 @@ class CardData {
     this.equip,
     this.domain,
     this.abilities = const [],
+    this.image,
   });
 }

--- a/lib/domain/models/card_selection_state.dart
+++ b/lib/domain/models/card_selection_state.dart
@@ -1,0 +1,20 @@
+import 'card_instance.dart';
+
+/// カードが選択されているゾーンを表す列挙型。
+enum SelectionZone { hand, board }
+
+/// ゲーム中にカードが選択された状態を表すデータクラス。
+/// GameState.selectedCard (ValueNotifier) で保持され、Flutter UI の詳細パネル表示に使用する。
+class CardSelectionState {
+  final CardInstance card;
+  final SelectionZone zone;
+
+  /// zone == SelectionZone.hand のとき、手札内のインデックス。
+  final int? handIndex;
+
+  const CardSelectionState({
+    required this.card,
+    required this.zone,
+    this.handIndex,
+  });
+}

--- a/lib/presentation/components/board_component.dart
+++ b/lib/presentation/components/board_component.dart
@@ -1,193 +1,375 @@
 // ignore_for_file: deprecated_member_use
-
 import 'package:flame/components.dart';
+import 'package:flame/events.dart';
 import 'package:flutter/material.dart' as material;
 
+import '../../domain/models/card_data.dart';
+import '../../domain/models/card_selection_state.dart';
+import '../../ui/theme/game_theme.dart';
 import '../game/tcg_game.dart';
 import './card_component.dart';
 
 /// ゲームの盤面全体を描画し、UI要素を管理するコンポーネント。
 ///
-/// このコンポーネントは、手札、フィールド、デッキ、ログなど、
-/// ゲームの視覚的な要素をすべて子コンポーネントとして保持・管理します。
-/// `GameState` の変更を検知し、UIをリアクティブに更新する責務を持ちます。
-class BoardComponent extends PositionComponent with HasGameRef<TCGGame> {
-  /// UI要素を管理するためのリスト
-  final List<Component> _handComponents = [];
-  final List<Component> _fieldComponents = [];
+/// - カードコンポーネントは instanceId をキーとした Map で差分管理する（毎フレーム再生成しない）。
+/// - タップ処理は2タップモデル：1回目で選択+詳細表示、2回目でプレイ/発動。
+/// - 空白タップ（子コンポーネントが消費しないタップ）で選択解除。
+class BoardComponent extends PositionComponent
+    with HasGameRef<TCGGame>, TapCallbacks {
+  // カードコンポーネントの差分管理マップ (instanceId → component)
+  final Map<String, CardComponent> _handComponentMap = {};
+  final Map<String, CardComponent> _fieldComponentMap = {};
+
+  // ログ・トリガーキュー用（テキストは毎フレーム再生成でも軽量）
   final List<Component> _logComponents = [];
   final List<Component> _triggerQueueComponents = [];
 
-  /// UIテキストコンポーネント
-  late final TextComponent _instructionComponent;
-  late final TextComponent _gameStatusComponent;
-  late final TextComponent _lifeComponent;
-
   @override
   Future<void> onLoad() async {
-    super.onLoad();
-    // ボードコンポーネントのサイズをゲーム画面全体に広げる
+    await super.onLoad();
     size = gameRef.size;
-
-    // 初期UIのセットアップ
-    _setupUI();
   }
 
   @override
   void update(double dt) {
     super.update(dt);
-    // 毎フレームUIの状態を最新に保つ
-    // 将来的には、GameStateの変更を通知するイベントベースの仕組みに移行すべき
-    _updateDisplay();
-  }
-
-  @override
-  void render(material.Canvas canvas) {
-    // 背景色を描画
-    canvas.drawRect(
-      material.Rect.fromLTWH(0, 0, size.x, size.y),
-      material.Paint()..color = material.Colors.black87,
-    );
-    super.render(canvas);
-  }
-
-  /// ゲーム画面の基本的なUI要素（テキストなど）を初期化します。
-  void _setupUI() {
-    _instructionComponent = TextComponent(
-      text: 'Tap cards in your hand to play them',
-      position: Vector2(20, 20),
-      textRenderer: TextPaint(
-        style: const material.TextStyle(
-          color: material.Colors.white,
-          fontSize: 16,
-        ),
-      ),
-    );
-    add(_instructionComponent);
-
-    _gameStatusComponent = TextComponent(
-      text: '', // updateで更新
-      position: Vector2(20, 50),
-      textRenderer: TextPaint(
-        style: const material.TextStyle(
-          color: material.Colors.yellow,
-          fontSize: 14,
-        ),
-      ),
-    );
-    add(_gameStatusComponent);
-
-    _lifeComponent = TextComponent(
-      text: '', // updateで更新
-      position: Vector2(size.x / 2 - 100, 20),
-      textRenderer: TextPaint(
-        style: const material.TextStyle(
-          color: material.Colors.green,
-          fontSize: 18,
-          fontWeight: material.FontWeight.bold,
-        ),
-      ),
-    );
-    add(_lifeComponent);
-  }
-
-  /// ゲームの状態に基づいてUI全体の表示を更新します。
-  void _updateDisplay() {
-    // 各UIセクションを更新
     _updateHand();
     _updateField();
     _updateLog();
     _updateTriggerQueue();
+  }
 
-    // ステータステキストを更新
-    _gameStatusComponent.text = _getGameStatusText();
-    _lifeComponent.text =
-        'Player Life: ${gameRef.gameState.playerLife} | Opponent Life: ${gameRef.gameState.opponentLife}';
+  @override
+  void render(material.Canvas canvas) {
+    // ─── ボード全体背景 ───────────────────────────────────────
+    canvas.drawRect(
+      material.Rect.fromLTWH(0, 0, size.x, size.y),
+      material.Paint()..color = GameTheme.boardBg,
+    );
 
-    // 勝利条件のチェック
-    if (gameRef.gameState.gameWon) {
-      // TODO: 勝利画面コンポーネントの表示
+    // ─── グリッドテクスチャ（微細） ───────────────────────────
+    final gridPaint = material.Paint()
+      ..color = material.Colors.white.withOpacity(0.020);
+    const gridSize = 40.0;
+    for (double x = 0; x < size.x; x += gridSize) {
+      canvas.drawLine(
+        material.Offset(x, 0),
+        material.Offset(x, size.y),
+        gridPaint,
+      );
     }
+    for (double y = 0; y < size.y; y += gridSize) {
+      canvas.drawLine(
+        material.Offset(0, y),
+        material.Offset(size.x, y),
+        gridPaint,
+      );
+    }
+
+    // ─── ゾーン背景 ───────────────────────────────────────────
+    _renderZone(canvas, _handZoneRect(), GameTheme.handZoneBg, '手札');
+    _renderZone(canvas, _boardZoneRect(), GameTheme.boardZoneBg, 'フィールド');
+    _renderZone(canvas, _domainZoneRect(), GameTheme.domainZoneBg, 'ドメイン');
+
+    // ─── HUD（ライフ・スペルカウンター） ─────────────────────
+    _renderHud(canvas);
+
+    // ─── ログパネル ───────────────────────────────────────────
+    _renderLogPanel(canvas);
+
+    super.render(canvas);
   }
 
-  /// ゲームの状態を示すステータステキストを生成します。
-  String _getGameStatusText() {
+  // ─── ゾーン矩形の定義 ────────────────────────────────────────
+
+  material.Rect _handZoneRect() =>
+      material.Rect.fromLTWH(10, 85, size.x - 20, 170);
+
+  material.Rect _boardZoneRect() =>
+      material.Rect.fromLTWH(size.x / 2 - 10, 265, size.x / 2, 160);
+
+  material.Rect _domainZoneRect() =>
+      material.Rect.fromLTWH(10, 265, size.x / 2 - 20, 160);
+
+  material.Rect _logPanelRect() =>
+      material.Rect.fromLTWH(10, size.y - 215, size.x * 0.6, 205);
+
+  void _renderZone(
+    material.Canvas canvas,
+    material.Rect rect,
+    material.Color bg,
+    String label,
+  ) {
+    final rRect = material.RRect.fromRectAndRadius(
+      rect,
+      const material.Radius.circular(10),
+    );
+    canvas.drawRRect(rRect, material.Paint()..color = bg);
+    canvas.drawRRect(
+      rRect,
+      material.Paint()
+        ..color = GameTheme.zoneBorder
+        ..style = material.PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+    // ゾーンラベル
+    final labelPainter = material.TextPainter(
+      text: material.TextSpan(
+        text: label,
+        style: material.TextStyle(
+          color: GameTheme.hudDimColor.withOpacity(0.7),
+          fontSize: 10,
+          fontWeight: material.FontWeight.w600,
+          letterSpacing: 1.2,
+        ),
+      ),
+      textDirection: material.TextDirection.ltr,
+    );
+    labelPainter.layout();
+    labelPainter.paint(
+      canvas,
+      material.Offset(rect.left + 8, rect.top + 5),
+    );
+  }
+
+  void _renderHud(material.Canvas canvas) {
     final state = gameRef.gameState;
-    return 'Hand: ${state.hand.count} | Deck: ${state.deck.count} | Grave: ${state.grave.count} | Life: ${state.playerLife} | Spells: ${state.spellsCastThisTurn}';
+    const hudY = 8.0;
+
+    // ライフポイントピル（左上）
+    _renderPill(
+      canvas,
+      '♥  ${state.playerLife}',
+      const material.Offset(10, 8),
+      GameTheme.hudLifeColor,
+    );
+
+    // スペルカウンター（ライフの右）
+    _renderPill(
+      canvas,
+      '✦  ${state.spellsCastThisTurn}スペル',
+      material.Offset(110, hudY),
+      GameTheme.hudSpellColor,
+    );
+
+    // デッキ・墓地カウント（右上）
+    _renderPill(
+      canvas,
+      '🂠 ${state.deck.count}',
+      material.Offset(size.x - 170, hudY),
+      GameTheme.hudDimColor,
+    );
+    _renderPill(
+      canvas,
+      '☠ ${state.grave.count}',
+      material.Offset(size.x - 95, hudY),
+      GameTheme.hudDimColor,
+    );
   }
 
-  /// 手札の表示を更新します。
+  void _renderPill(
+    material.Canvas canvas,
+    String text,
+    material.Offset pos,
+    material.Color color,
+  ) {
+    final painter = material.TextPainter(
+      text: material.TextSpan(
+        text: text,
+        style: material.TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: material.FontWeight.w600,
+        ),
+      ),
+      textDirection: material.TextDirection.ltr,
+    );
+    painter.layout();
+    final pillRect = material.RRect.fromRectAndRadius(
+      material.Rect.fromLTWH(
+        pos.dx - 6,
+        pos.dy - 3,
+        painter.width + 12,
+        painter.height + 6,
+      ),
+      const material.Radius.circular(12),
+    );
+    canvas.drawRRect(
+      pillRect,
+      material.Paint()..color = color.withOpacity(0.15),
+    );
+    canvas.drawRRect(
+      pillRect,
+      material.Paint()
+        ..color = color.withOpacity(0.4)
+        ..style = material.PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+    painter.paint(canvas, pos);
+  }
+
+  void _renderLogPanel(material.Canvas canvas) {
+    final rect = _logPanelRect();
+    // 半透明パネル
+    canvas.drawRRect(
+      material.RRect.fromRectAndRadius(rect, const material.Radius.circular(8)),
+      material.Paint()..color = GameTheme.logPanelBg,
+    );
+  }
+
+  // ─── 手札の差分更新 ──────────────────────────────────────────
+
   void _updateHand() {
-    // 既存のコンポーネントをクリア
-    removeAll(_handComponents);
-    _handComponents.clear();
-
     final state = gameRef.gameState;
+    final currentIds = state.hand.cards.map((c) => c.instanceId).toSet();
+
+    // 手札から消えたカードを削除
+    final toRemove = _handComponentMap.keys
+        .where((id) => !currentIds.contains(id))
+        .toList();
+    for (final id in toRemove) {
+      final comp = _handComponentMap.remove(id);
+      if (comp != null) remove(comp);
+    }
+
+    // 手札のカードを追加・位置更新
     for (int i = 0; i < state.hand.count; i++) {
       final card = state.hand.cards[i];
-      final component = CardComponent(
-        card: card,
-        position: Vector2(20 + i * 120, 100),
-        onTap: () => gameRef.playCardFromHand(i),
-      );
-      _handComponents.add(component);
-      add(component);
+      final targetPos = Vector2(20 + i * 120.0, 100);
+
+      if (_handComponentMap.containsKey(card.instanceId)) {
+        // 位置のみ更新
+        _handComponentMap[card.instanceId]!.position = targetPos;
+      } else {
+        // 新規追加
+        final component = CardComponent(
+          card: card,
+          position: targetPos,
+          onTap: () {
+            final sel = gameRef.gameState.selectedCard.value;
+            if (sel?.card.instanceId == card.instanceId) {
+              // 2回目タップ: プレイ
+              gameRef.gameState.selectCard(null);
+              gameRef.playCardFromHand(i);
+            } else {
+              // 1回目タップ: 選択
+              gameRef.gameState.selectCard(CardSelectionState(
+                card: card,
+                zone: SelectionZone.hand,
+                handIndex: i,
+              ));
+            }
+          },
+        );
+        _handComponentMap[card.instanceId] = component;
+        add(component);
+      }
     }
   }
 
-  /// フィールド（盤面）の表示を更新します。
-  void _updateField() {
-    removeAll(_fieldComponents);
-    _fieldComponents.clear();
+  // ─── フィールドの差分更新 ─────────────────────────────────────
 
+  void _updateField() {
     final state = gameRef.gameState;
 
-    // ドメインカードの表示
+    // フィールド上の有効なカード ID セット（ドメイン含む）
+    final currentIds = <String>{};
     if (state.hasDomain) {
-      final domainCard = state.currentDomain!;
-      final component = CardComponent(
-        card: domainCard,
-        position: Vector2(size.x / 2 - 150, 250),
-        onTap: null, // ドメインはタップ不可
-        isField: true,
-      );
-      _fieldComponents.add(component);
-      add(component);
+      currentIds.add(state.currentDomain!.instanceId);
+    }
+    for (final c in state.board.cards) {
+      currentIds.add(c.instanceId);
     }
 
-    // ボード上のカードの表示
+    // 消えたカードを削除
+    final toRemove = _fieldComponentMap.keys
+        .where((id) => !currentIds.contains(id))
+        .toList();
+    for (final id in toRemove) {
+      final comp = _fieldComponentMap.remove(id);
+      if (comp != null) remove(comp);
+    }
+
+    // ドメインカード
+    if (state.hasDomain) {
+      final domainCard = state.currentDomain!;
+      final targetPos = Vector2(size.x / 2 - 160, 280);
+      if (_fieldComponentMap.containsKey(domainCard.instanceId)) {
+        _fieldComponentMap[domainCard.instanceId]!.position = targetPos;
+      } else {
+        final component = CardComponent(
+          card: domainCard,
+          position: targetPos,
+          isField: true,
+          onTap: () {
+            // ドメインはタップで詳細のみ表示
+            gameRef.gameState.selectCard(CardSelectionState(
+              card: domainCard,
+              zone: SelectionZone.board,
+            ));
+          },
+        );
+        _fieldComponentMap[domainCard.instanceId] = component;
+        add(component);
+      }
+    }
+
+    // ボード上のカード
     for (int i = 0; i < state.board.count; i++) {
       final boardCard = state.board.cards[i];
-      final component = CardComponent(
-        card: boardCard,
-        position: Vector2(size.x / 2 - 50 + i * 70, 350),
-        onTap: () => gameRef.activateCardOnBoard(boardCard),
-        isField: true,
-      );
-      _fieldComponents.add(component);
-      add(component);
+      final targetPos = Vector2(size.x / 2 + 10 + i * 115.0, 280);
+      final hasActivated = boardCard.card.abilities
+          .any((a) => a.when == TriggerWhen.activated);
+
+      if (_fieldComponentMap.containsKey(boardCard.instanceId)) {
+        _fieldComponentMap[boardCard.instanceId]!.position = targetPos;
+      } else {
+        final component = CardComponent(
+          card: boardCard,
+          position: targetPos,
+          isField: true,
+          onTap: () {
+            final sel = gameRef.gameState.selectedCard.value;
+            if (hasActivated && sel?.card.instanceId == boardCard.instanceId) {
+              // 2回目タップ: 発動
+              gameRef.gameState.selectCard(null);
+              gameRef.activateCardOnBoard(boardCard);
+            } else {
+              // 1回目タップ: 選択（activated がなくても詳細表示）
+              gameRef.gameState.selectCard(CardSelectionState(
+                card: boardCard,
+                zone: SelectionZone.board,
+              ));
+            }
+          },
+        );
+        _fieldComponentMap[boardCard.instanceId] = component;
+        add(component);
+      }
     }
   }
 
-  /// アクションログの表示を更新します。
+  // ─── ログ・トリガーキュー ─────────────────────────────────────
+
   void _updateLog() {
     removeAll(_logComponents);
     _logComponents.clear();
 
-    // 最新10件のログを表示
     final recentLogs = gameRef.gameState.actionLog.reversed
-        .take(10)
+        .take(9)
         .toList()
         .reversed
         .toList();
+
     for (int i = 0; i < recentLogs.length; i++) {
+      final isRecent = i == recentLogs.length - 1;
       final logComponent = TextComponent(
         text: recentLogs[i],
-        position: Vector2(20, size.y - 200 + i * 18),
+        position: Vector2(18, size.y - 205 + i * 20),
         textRenderer: TextPaint(
-          style: const material.TextStyle(
-            color: material.Colors.white,
-            fontSize: 12,
+          style: material.TextStyle(
+            color: isRecent ? GameTheme.logTextRecent : GameTheme.logTextOld,
+            fontSize: 11,
           ),
         ),
       );
@@ -196,20 +378,21 @@ class BoardComponent extends PositionComponent with HasGameRef<TCGGame> {
     }
   }
 
-  /// トリガーキューの表示を更新します。
   void _updateTriggerQueue() {
     removeAll(_triggerQueueComponents);
     _triggerQueueComponents.clear();
 
     final state = gameRef.gameState;
+    final queue = state.triggerQueue.toList();
+    if (queue.isEmpty) return;
 
     final queueTitle = TextComponent(
-      text: 'Trigger Queue:',
-      position: Vector2(size.x - 220, 50),
+      text: 'チェーン:',
+      position: Vector2(size.x - 180, 50),
       textRenderer: TextPaint(
         style: const material.TextStyle(
           color: material.Colors.orange,
-          fontSize: 14,
+          fontSize: 13,
           fontWeight: material.FontWeight.bold,
         ),
       ),
@@ -217,22 +400,29 @@ class BoardComponent extends PositionComponent with HasGameRef<TCGGame> {
     _triggerQueueComponents.add(queueTitle);
     add(queueTitle);
 
-    final queue = state.triggerQueue.toList();
     for (int i = 0; i < queue.length; i++) {
       final trigger = queue[i];
-      final text = '${i + 1}: ${trigger.source.card.name}';
       final component = TextComponent(
-        text: text,
-        position: Vector2(size.x - 220, 70 + i * 18),
+        text: '${i + 1}. ${trigger.source.card.name}',
+        position: Vector2(size.x - 180, 66 + i * 18),
         textRenderer: TextPaint(
           style: const material.TextStyle(
-            color: material.Colors.white,
-            fontSize: 12,
+            color: material.Colors.white70,
+            fontSize: 11,
           ),
         ),
       );
       _triggerQueueComponents.add(component);
       add(component);
     }
+  }
+
+  // ─── 空白タップで選択解除 ─────────────────────────────────────
+
+  @override
+  bool onTapDown(TapDownEvent event) {
+    // 子コンポーネントがイベントを消費しなかった場合のみここに来る
+    gameRef.gameState.selectCard(null);
+    return false; // イベントは消費しない（Flame の伝播処理に従う）
   }
 }

--- a/lib/presentation/components/board_component.dart
+++ b/lib/presentation/components/board_component.dart
@@ -248,15 +248,21 @@ class BoardComponent extends PositionComponent
           onTap: () {
             final sel = gameRef.gameState.selectedCard.value;
             if (sel?.card.instanceId == card.instanceId) {
-              // 2回目タップ: プレイ
+              // 2回目タップ: instanceId から実行時点の正しいインデックスを検索してプレイ
+              final currentIndex = gameRef.gameState.hand.cards
+                  .indexWhere((c) => c.instanceId == card.instanceId);
+              if (currentIndex == -1) return; // 既に手札から消えている
               gameRef.gameState.selectCard(null);
-              gameRef.playCardFromHand(i);
+              gameRef.playCardFromHand(currentIndex);
             } else {
-              // 1回目タップ: 選択
+              // 1回目タップ: 選択（handIndex も実行時点で解決）
+              final currentIndex = gameRef.gameState.hand.cards
+                  .indexWhere((c) => c.instanceId == card.instanceId);
+              if (currentIndex == -1) return;
               gameRef.gameState.selectCard(CardSelectionState(
                 card: card,
                 zone: SelectionZone.hand,
-                handIndex: i,
+                handIndex: currentIndex,
               ));
             }
           },

--- a/lib/presentation/components/card_component.dart
+++ b/lib/presentation/components/card_component.dart
@@ -1,23 +1,29 @@
+// ignore_for_file: deprecated_member_use
+import 'dart:ui' as ui;
+
 import 'package:flame/components.dart';
 import 'package:flame/events.dart';
-import 'package:flame/game.dart';
 import 'package:flutter/material.dart' as material;
 import '../../domain/models/card_data.dart';
 import '../../domain/models/card_instance.dart';
+import '../../presentation/game/tcg_game.dart';
+import '../../ui/theme/game_theme.dart';
 
 /// カードの見た目を描画し、タップイベントを処理するコンポーネント。
 ///
-/// このコンポーネントはカードの「状態」や「ロジック」を持たず、
-/// 与えられた `CardInstance` に基づいて自身を描画することに専念します。
-class CardComponent extends PositionComponent with TapCallbacks {
+/// 描画は毎フレーム行われ、選択グローは GameState.selectedCard を参照して自動更新される。
+/// カード画像がある場合は Sprite としてレンダリングし、ない場合はグラデーション矩形で代替する。
+class CardComponent extends PositionComponent with TapCallbacks, HasGameRef<TCGGame> {
   /// 描画対象のカードインスタンス。
   final CardInstance card;
 
   /// カードがタップされたときに実行されるコールバック関数。
   final material.VoidCallback? onTap;
 
-  /// フィールド上のカードかどうか。描画に影響を与える可能性があります。
+  /// フィールド上のカードかどうか。
   final bool isField;
+
+  Sprite? _sprite;
 
   CardComponent({
     required this.card,
@@ -26,138 +32,208 @@ class CardComponent extends PositionComponent with TapCallbacks {
     this.isField = false,
   }) : super(
           position: position,
-          size: Vector2(100, 140), // カードの固定サイズ
+          size: Vector2(100, 140),
         );
 
-  /// カードの種類に基づいてベースカラーを決定します。
-  material.Color _getCardBaseColor() {
-    switch (card.card.type) {
-      case CardType.monster:
-        return material.Colors.brown.shade700;
-      case CardType.ritual:
-        return material.Colors.purple.shade700;
-      case CardType.spell:
-        return material.Colors.green.shade700;
-      case CardType.arcane:
-        return material.Colors.teal.shade700;
-      case CardType.artifact:
-        return material.Colors.orange.shade700;
-      case CardType.relic:
-        return material.Colors.deepOrange.shade700;
-      case CardType.equip:
-        return material.Colors.yellow.shade700;
-      case CardType.domain:
-        return material.Colors.blue.shade700;
-      default:
-        return material.Colors.grey.shade700;
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    if (card.card.image != null) {
+      try {
+        _sprite = await gameRef.loadSprite('images/cards/${card.card.image}');
+      } catch (_) {
+        // 画像ロード失敗時はグラデーション矩形にフォールバック
+      }
     }
   }
 
-  /// カードの種類に基づいて内側のカラーを決定します。
-  material.Color _getCardInnerColor() {
-    switch (card.card.type) {
-      case CardType.monster:
-        return material.Colors.brown.shade300;
-      case CardType.ritual:
-        return material.Colors.purple.shade300;
-      case CardType.spell:
-        return material.Colors.green.shade300;
-      case CardType.arcane:
-        return material.Colors.teal.shade300;
-      case CardType.artifact:
-        return material.Colors.orange.shade300;
-      case CardType.relic:
-        return material.Colors.deepOrange.shade300;
-      case CardType.equip:
-        return material.Colors.yellow.shade300;
-      case CardType.domain:
-        return material.Colors.blue.shade300;
-      default:
-        return material.Colors.grey.shade300;
-    }
-  }
+  bool get _isSelected =>
+      gameRef.gameState.selectedCard.value?.card.instanceId == card.instanceId;
 
   @override
   void render(material.Canvas canvas) {
     super.render(canvas);
 
-    // カードのベース（外枠）を描画
+    final outerRect = material.Rect.fromLTWH(0, 0, size.x, size.y);
+    final outerRRect = material.RRect.fromRectAndRadius(
+      outerRect,
+      const material.Radius.circular(8),
+    );
+
+    // 選択グロー（外枠ブラー）
+    if (_isSelected) {
+      canvas.drawRRect(
+        outerRRect,
+        material.Paint()
+          ..color = GameTheme.selectionGlow.withOpacity(0.5)
+          ..maskFilter = const material.MaskFilter.blur(material.BlurStyle.outer, 8),
+      );
+    }
+
+    // カードのベース（グラデーション外枠）
+    final gradColors = GameTheme.cardGradient(card.card.type);
+    final shader = ui.Gradient.linear(
+      const ui.Offset(0, 0),
+      ui.Offset(0, size.y),
+      gradColors,
+    );
     canvas.drawRRect(
-      material.RRect.fromRectAndRadius(
-        material.Rect.fromLTWH(0, 0, size.x, size.y),
-        const material.Radius.circular(8),
-      ),
-      material.Paint()
-        ..color = _getCardBaseColor()
-        ..style = material.PaintingStyle.fill,
+      outerRRect,
+      material.Paint()..shader = shader,
     );
 
-    // カードの内側を描画
+    // 内側の暗いパネル
+    final innerRRect = material.RRect.fromRectAndRadius(
+      material.Rect.fromLTWH(2, 2, size.x - 4, size.y - 4),
+      const material.Radius.circular(6),
+    );
     canvas.drawRRect(
-      material.RRect.fromRectAndRadius(
-        material.Rect.fromLTWH(2, 2, size.x - 4, size.y - 4),
-        const material.Radius.circular(6),
-      ),
-      material.Paint()
-        ..color = _getCardInnerColor()
-        ..style = material.PaintingStyle.fill,
+      innerRRect,
+      material.Paint()..color = gradColors[0].withOpacity(0.85),
     );
 
-    // カード名を描画
-    final textPainter = material.TextPainter(
-      text: material.TextSpan(
-        text: card.card.name,
-        style: const material.TextStyle(
-          color: material.Colors.white,
-          fontSize: 10,
-          fontWeight: material.FontWeight.bold,
-        ),
-      ),
-      textDirection: material.TextDirection.ltr,
-    );
-    textPainter.layout(maxWidth: size.x - 8);
-    textPainter.paint(canvas, const material.Offset(4, 4));
+    // カード画像 or プレースホルダー（上部 55%）
+    const imageTop = 18.0;
+    final imageHeight = size.y * 0.52;
+    final imageRect = material.Rect.fromLTWH(3, imageTop, size.x - 6, imageHeight);
 
-    // カード種別を描画
-    final typePainter = material.TextPainter(
-      text: material.TextSpan(
-        text: card.card.type.toString().split('.').last,
-        style: const material.TextStyle(
-          color: material.Colors.white70,
-          fontSize: 8,
-        ),
-      ),
-      textDirection: material.TextDirection.ltr,
-    );
-    typePainter.layout();
-    typePainter.paint(canvas, material.Offset(4, size.y - 16));
-
-    // モンスターとリチュアルのステータスを描画
-    if (card.card.type == CardType.monster ||
-        card.card.type == CardType.ritual) {
-      final statsPainter = material.TextPainter(
+    if (_sprite != null) {
+      _sprite!.render(
+        canvas,
+        position: Vector2(imageRect.left, imageRect.top),
+        size: Vector2(imageRect.width, imageRect.height),
+      );
+    } else {
+      // グラデーションプレースホルダー
+      final placeholderShader = ui.Gradient.linear(
+        ui.Offset(imageRect.left, imageRect.top),
+        ui.Offset(imageRect.right, imageRect.bottom),
+        [gradColors[1].withOpacity(0.5), gradColors[0].withOpacity(0.3)],
+      );
+      canvas.drawRect(
+        imageRect,
+        material.Paint()..shader = placeholderShader,
+      );
+      // カード種別アイコン文字（プレースホルダー中央）
+      final iconPainter = material.TextPainter(
         text: material.TextSpan(
-          text:
-              'ATK: ${card.stats.atk} | DEF: ${card.stats.def} | HP: ${card.stats.hp}',
-          style: const material.TextStyle(
-            color: material.Colors.white,
-            fontSize: 8,
+          text: _cardTypeIcon(card.card.type),
+          style: material.TextStyle(
+            color: material.Colors.white.withOpacity(0.4),
+            fontSize: 24,
           ),
         ),
         textDirection: material.TextDirection.ltr,
       );
-      statsPainter.layout(maxWidth: size.x - 8);
-      statsPainter.paint(canvas, material.Offset(4, size.y - 28));
+      iconPainter.layout();
+      iconPainter.paint(
+        canvas,
+        material.Offset(
+          imageRect.left + (imageRect.width - iconPainter.width) / 2,
+          imageRect.top + (imageRect.height - iconPainter.height) / 2,
+        ),
+      );
+    }
+
+    // カード名
+    final namePainter = material.TextPainter(
+      text: material.TextSpan(
+        text: card.card.name,
+        style: const material.TextStyle(
+          color: material.Colors.white,
+          fontSize: 9,
+          fontWeight: material.FontWeight.bold,
+          shadows: [
+            material.Shadow(color: material.Colors.black, blurRadius: 2),
+          ],
+        ),
+      ),
+      textDirection: material.TextDirection.ltr,
+    );
+    namePainter.layout(maxWidth: size.x - 8);
+    namePainter.paint(canvas, const material.Offset(4, 4));
+
+    // モンスター・リチュアルのステータス
+    if (card.card.type == CardType.monster || card.card.type == CardType.ritual) {
+      final s = card.stats;
+      // ignore: unnecessary_null_comparison
+      if (s != null) {
+        _drawStatsBadge(canvas, 'ATK ${s.atk}', size.y - 38);
+        _drawStatsBadge(canvas, 'DEF ${s.def}', size.y - 26);
+        _drawStatsBadge(canvas, 'HP  ${s.hp}', size.y - 14);
+      }
+    } else {
+      // 種別バッジ（下部）
+      final typePainter = material.TextPainter(
+        text: material.TextSpan(
+          text: GameTheme.cardTypeName(card.card.type),
+          style: material.TextStyle(
+            color: GameTheme.cardAccentColor(card.card.type),
+            fontSize: 7,
+            fontWeight: material.FontWeight.w600,
+          ),
+        ),
+        textDirection: material.TextDirection.ltr,
+      );
+      typePainter.layout();
+      typePainter.paint(canvas, material.Offset(4, size.y - 13));
+    }
+
+    // 選択中ゴールドボーダー
+    if (_isSelected) {
+      canvas.drawRRect(
+        outerRRect,
+        material.Paint()
+          ..color = GameTheme.selectionBorder
+          ..style = material.PaintingStyle.stroke
+          ..strokeWidth = 2.0,
+      );
+    }
+  }
+
+  void _drawStatsBadge(material.Canvas canvas, String text, double y) {
+    final painter = material.TextPainter(
+      text: material.TextSpan(
+        text: text,
+        style: const material.TextStyle(
+          color: material.Colors.white,
+          fontSize: 7,
+          fontWeight: material.FontWeight.w500,
+        ),
+      ),
+      textDirection: material.TextDirection.ltr,
+    );
+    painter.layout(maxWidth: size.x - 8);
+    painter.paint(canvas, material.Offset(4, y));
+  }
+
+  String _cardTypeIcon(CardType type) {
+    switch (type) {
+      case CardType.monster:
+        return '⚔';
+      case CardType.ritual:
+        return '✦';
+      case CardType.spell:
+        return '✦';
+      case CardType.arcane:
+        return '✧';
+      case CardType.artifact:
+        return '⬡';
+      case CardType.relic:
+        return '◈';
+      case CardType.equip:
+        return '🛡';
+      case CardType.domain:
+        return '◉';
     }
   }
 
   @override
   bool onTapDown(TapDownEvent event) {
-    // onTap コールバックが設定されていれば実行する
     if (onTap != null) {
       onTap!();
-      return true; // イベントを消費
+      return true;
     }
-    return false; // イベントを伝播
+    return false;
   }
 }

--- a/lib/presentation/game/tcg_game.dart
+++ b/lib/presentation/game/tcg_game.dart
@@ -23,7 +23,8 @@ import '../components/board_component.dart';
 /// `BoardComponent` などの子コンポーネントに責務を委譲します。
 class TCGGame extends FlameGame {
   /// ゲーム全体の共有状態。信頼できる唯一の情報源 (Single Source of Truth)。
-  late final GameState gameState;
+  /// GameScreen の build() が onLoad() より先に呼ばれるため、コンストラクタ時に初期化する。
+  final GameState gameState = GameState();
 
   /// ゲームで使用するデッキ
   final Deck? initialDeck;
@@ -33,9 +34,6 @@ class TCGGame extends FlameGame {
   @override
   Future<void> onLoad() async {
     super.onLoad();
-
-    // ゲーム状態を初期化
-    gameState = GameState();
 
     // ゲームの初期設定を行う
     await _initializeGame();

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -1,54 +1,96 @@
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
+import '../../domain/models/card_selection_state.dart';
 import '../../domain/models/deck.dart';
 import '../../presentation/game/tcg_game.dart';
+import '../widgets/card_detail_panel.dart';
 
 /// ゲームプレイ画面
-class GameScreen extends StatelessWidget {
+///
+/// TCGGame インスタンスを initState で生成して保持し、
+/// selectedCard ValueNotifier を購読してカード詳細パネルを表示する。
+class GameScreen extends StatefulWidget {
   final Deck? deck;
 
   const GameScreen({super.key, this.deck});
 
   @override
+  State<GameScreen> createState() => _GameScreenState();
+}
+
+class _GameScreenState extends State<GameScreen> {
+  late final TCGGame _game;
+
+  @override
+  void initState() {
+    super.initState();
+    _game = TCGGame(initialDeck: widget.deck);
+  }
+
+  void _handleConfirm(CardSelectionState sel) {
+    _game.gameState.selectCard(null);
+    if (sel.zone == SelectionZone.hand && sel.handIndex != null) {
+      _game.playCardFromHand(sel.handIndex!);
+    } else if (sel.zone == SelectionZone.board) {
+      _game.activateCardOnBoard(sel.card);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Game'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.help_outline),
-            onPressed: () {
-              // TODO: ヘルプ画面表示
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('ヘルプ機能は実装中です')),
+      backgroundColor: const Color(0xFF0D1117),
+      body: Stack(
+        children: [
+          GameWidget(
+            game: _game,
+            loadingBuilder: (context) => const Center(
+              child: CircularProgressIndicator(
+                color: Color(0xFFFFD700),
+              ),
+            ),
+            errorBuilder: (context, error) => Center(
+              child: Text(
+                'エラーが発生しました: $error',
+                style: const TextStyle(color: Colors.red),
+              ),
+            ),
+            overlayBuilderMap: {
+              'pause': (context, TCGGame game) => Center(
+                child: Container(
+                  color: Colors.black54,
+                  child: const Text(
+                    '一時停止中',
+                    style: TextStyle(color: Colors.white, fontSize: 24),
+                  ),
+                ),
+              ),
+            },
+          ),
+          // カード詳細パネル（選択時にスライドイン）
+          ValueListenableBuilder<CardSelectionState?>(
+            valueListenable: _game.gameState.selectedCard,
+            builder: (context, selection, _) {
+              return AnimatedSlide(
+                offset: selection != null ? Offset.zero : const Offset(0, 1),
+                duration: const Duration(milliseconds: 220),
+                curve: Curves.easeOutCubic,
+                child: AnimatedOpacity(
+                  opacity: selection != null ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 180),
+                  child: selection != null
+                      ? CardDetailPanel(
+                          selection: selection,
+                          onConfirm: _handleConfirm,
+                          onDismiss: () => _game.gameState.selectCard(null),
+                        )
+                      : const SizedBox.shrink(),
+                ),
               );
             },
           ),
         ],
-      ),
-      body: GameWidget(
-        game: TCGGame(initialDeck: deck),
-        loadingBuilder: (context) => const Center(
-          child: CircularProgressIndicator(),
-        ),
-        errorBuilder: (context, error) => Center(
-          child: Text(
-            'エラーが発生しました: $error',
-            style: const TextStyle(color: Colors.red),
-          ),
-        ),
-        overlayBuilderMap: {
-          'pause': (context, TCGGame game) => Center(
-            child: Container(
-              color: Colors.black54,
-              child: const Text(
-                '一時停止中',
-                style: TextStyle(color: Colors.white, fontSize: 24),
-              ),
-            ),
-          ),
-        },
       ),
     );
   }

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -30,8 +30,12 @@ class _GameScreenState extends State<GameScreen> {
 
   void _handleConfirm(CardSelectionState sel) {
     _game.gameState.selectCard(null);
-    if (sel.zone == SelectionZone.hand && sel.handIndex != null) {
-      _game.playCardFromHand(sel.handIndex!);
+    if (sel.zone == SelectionZone.hand) {
+      // 選択時点の handIndex ではなく、実行時点の instanceId から正しいインデックスを解決する
+      final currentIndex = _game.gameState.hand.cards
+          .indexWhere((c) => c.instanceId == sel.card.instanceId);
+      if (currentIndex == -1) return;
+      _game.playCardFromHand(currentIndex);
     } else if (sel.zone == SelectionZone.board) {
       _game.activateCardOnBoard(sel.card);
     }

--- a/lib/ui/theme/game_theme.dart
+++ b/lib/ui/theme/game_theme.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import '../../domain/models/card_data.dart';
+
+/// ゲーム画面全体で使用するビジュアル定数。
+/// すべての色・グラデーション・タイポグラフィはここで一元管理する。
+class GameTheme {
+  GameTheme._();
+
+  // ─── ボード背景 ───────────────────────────────────────────
+  static const Color boardBg = Color(0xFF0D1117);
+  static const Color zoneBg = Color(0xFF161B22);
+  static const Color zoneBorder = Color(0xFF30363D);
+
+  // ─── ゾーン背景 ───────────────────────────────────────────
+  static const Color handZoneBg = Color(0xFF0F2014);
+  static const Color boardZoneBg = Color(0xFF0F0F2A);
+  static const Color domainZoneBg = Color(0xFF1A1020);
+  static const Color graveZoneBg = Color(0xFF1A1010);
+
+  // ─── HUD ─────────────────────────────────────────────────
+  static const Color hudBg = Color(0xCC0D1117);
+  static const Color hudLifeColor = Color(0xFF22C55E);
+  static const Color hudSpellColor = Color(0xFFA855F7);
+  static const Color hudTextColor = Color(0xFFE2E8F0);
+  static const Color hudDimColor = Color(0xFF64748B);
+
+  // ─── 選択グロー ───────────────────────────────────────────
+  static const Color selectionGlow = Color(0xFFFFD700);
+  static const Color selectionBorder = Color(0xFFFFD700);
+
+  // ─── ログパネル ───────────────────────────────────────────
+  static const Color logPanelBg = Color(0xCC0D1117);
+  static const Color logTextRecent = Color(0xFFE2E8F0);
+  static const Color logTextOld = Color(0xFF64748B);
+
+  // ─── カード種別グラデーション (dark, light) ──────────────
+  static List<Color> cardGradient(CardType type) {
+    switch (type) {
+      case CardType.monster:
+        return [const Color(0xFF5C3317), const Color(0xFF9B6B3A)];
+      case CardType.ritual:
+        return [const Color(0xFF3B1F5E), const Color(0xFF7C4DA0)];
+      case CardType.spell:
+        return [const Color(0xFF1A4731), const Color(0xFF2E8B57)];
+      case CardType.arcane:
+        return [const Color(0xFF0F3D3D), const Color(0xFF1F7A7A)];
+      case CardType.artifact:
+        return [const Color(0xFF5C3D00), const Color(0xFFB07D20)];
+      case CardType.relic:
+        return [const Color(0xFF5C2200), const Color(0xFFB04820)];
+      case CardType.equip:
+        return [const Color(0xFF4A4A00), const Color(0xFF9A9A00)];
+      case CardType.domain:
+        return [const Color(0xFF0F2A5C), const Color(0xFF1F5CA0)];
+    }
+  }
+
+  /// カード種別の表示名（日本語）
+  static String cardTypeName(CardType type) {
+    switch (type) {
+      case CardType.monster:
+        return 'モンスター';
+      case CardType.ritual:
+        return 'リチュアル';
+      case CardType.spell:
+        return 'スペル';
+      case CardType.arcane:
+        return 'アルカナ';
+      case CardType.artifact:
+        return 'アーティファクト';
+      case CardType.relic:
+        return 'レリック';
+      case CardType.equip:
+        return '装備';
+      case CardType.domain:
+        return 'ドメイン';
+    }
+  }
+
+  /// カード種別のアクセントカラー（バッジ・ラベル用）
+  static Color cardAccentColor(CardType type) {
+    switch (type) {
+      case CardType.monster:
+        return const Color(0xFFB07D40);
+      case CardType.ritual:
+        return const Color(0xFF9B6BBF);
+      case CardType.spell:
+        return const Color(0xFF3DBF7A);
+      case CardType.arcane:
+        return const Color(0xFF3DBFBF);
+      case CardType.artifact:
+        return const Color(0xFFCFA040);
+      case CardType.relic:
+        return const Color(0xFFCF6040);
+      case CardType.equip:
+        return const Color(0xFFCFCF40);
+      case CardType.domain:
+        return const Color(0xFF4080CF);
+    }
+  }
+}

--- a/lib/ui/widgets/card_detail_panel.dart
+++ b/lib/ui/widgets/card_detail_panel.dart
@@ -1,0 +1,372 @@
+// ignore_for_file: deprecated_member_use
+import 'package:flutter/material.dart';
+import '../../domain/models/card_data.dart';
+import '../../domain/models/card_selection_state.dart';
+import '../theme/game_theme.dart';
+
+/// カード選択時に画面下部にスライドインするカード詳細パネル。
+///
+/// 選択されたカードの画像（あれば）・名前・種別・ステータス・効果テキストを表示し、
+/// プレイ/発動/閉じるのアクションを提供する。
+class CardDetailPanel extends StatelessWidget {
+  final CardSelectionState selection;
+  final void Function(CardSelectionState) onConfirm;
+  final VoidCallback onDismiss;
+
+  const CardDetailPanel({
+    super.key,
+    required this.selection,
+    required this.onConfirm,
+    required this.onDismiss,
+  });
+
+  bool get _hasActivated => selection.card.card.abilities
+      .any((a) => a.when == TriggerWhen.activated);
+
+  bool get _canAct {
+    if (selection.zone == SelectionZone.hand) return true;
+    if (selection.zone == SelectionZone.board && _hasActivated) return true;
+    return false;
+  }
+
+  String get _actionLabel {
+    if (selection.zone == SelectionZone.hand) return 'プレイ';
+    if (selection.zone == SelectionZone.board && _hasActivated) return '発動';
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          decoration: BoxDecoration(
+            color: const Color(0xF0161B22),
+            border: const Border(
+              top: BorderSide(color: Color(0xFF30363D), width: 1),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.6),
+                blurRadius: 20,
+                offset: const Offset(0, -4),
+              ),
+            ],
+          ),
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _CardArtwork(card: selection.card.card),
+                  const SizedBox(width: 16),
+                  Expanded(child: _CardInfo(card: selection.card.card)),
+                  const SizedBox(width: 12),
+                  _ActionButtons(
+                    canAct: _canAct,
+                    actionLabel: _actionLabel,
+                    onConfirm: () => onConfirm(selection),
+                    onDismiss: onDismiss,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CardArtwork extends StatelessWidget {
+  final CardData card;
+  const _CardArtwork({required this.card});
+
+  @override
+  Widget build(BuildContext context) {
+    final gradColors = GameTheme.cardGradient(card.type);
+    return Container(
+      width: 80,
+      height: 112,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: gradColors,
+        ),
+        border: Border.all(
+          color: GameTheme.cardAccentColor(card.type).withOpacity(0.6),
+          width: 1.5,
+        ),
+      ),
+      child: card.image != null
+          ? ClipRRect(
+              borderRadius: BorderRadius.circular(6.5),
+              child: Image.asset(
+                'assets/images/cards/${card.image}',
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => _placeholder(gradColors),
+              ),
+            )
+          : _placeholder(gradColors),
+    );
+  }
+
+  Widget _placeholder(List<Color> gradColors) {
+    return Center(
+      child: Text(
+        _typeIcon(card.type),
+        style: TextStyle(
+          fontSize: 32,
+          color: gradColors[1].withOpacity(0.7),
+        ),
+      ),
+    );
+  }
+
+  String _typeIcon(CardType type) {
+    switch (type) {
+      case CardType.monster:
+        return '⚔';
+      case CardType.ritual:
+        return '✦';
+      case CardType.spell:
+        return '✦';
+      case CardType.arcane:
+        return '✧';
+      case CardType.artifact:
+        return '⬡';
+      case CardType.relic:
+        return '◈';
+      case CardType.equip:
+        return '🛡';
+      case CardType.domain:
+        return '◉';
+    }
+  }
+}
+
+class _CardInfo extends StatelessWidget {
+  final CardData card;
+  const _CardInfo({required this.card});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Text(
+                card.name,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: GameTheme.cardAccentColor(card.type).withOpacity(0.2),
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(
+                  color: GameTheme.cardAccentColor(card.type).withOpacity(0.5),
+                ),
+              ),
+              child: Text(
+                GameTheme.cardTypeName(card.type),
+                style: TextStyle(
+                  color: GameTheme.cardAccentColor(card.type),
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+        if (card.stats != null) ...[
+          const SizedBox(height: 6),
+          _StatsRow(stats: card.stats!),
+        ],
+        if (card.text.isNotEmpty) ...[
+          const SizedBox(height: 6),
+          Text(
+            card.text,
+            style: const TextStyle(
+              color: Color(0xFFCBD5E1),
+              fontSize: 12,
+              height: 1.4,
+            ),
+            maxLines: 4,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+        if (card.abilities.isNotEmpty) ...[
+          const SizedBox(height: 6),
+          ..._buildAbilityTexts(card),
+        ],
+      ],
+    );
+  }
+
+  List<Widget> _buildAbilityTexts(CardData card) {
+    return card.abilities.map((ability) {
+      final timingLabel = _timingLabel(ability.when);
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 2),
+        child: RichText(
+          text: TextSpan(
+            children: [
+              TextSpan(
+                text: '[$timingLabel] ',
+                style: const TextStyle(
+                  color: Color(0xFFFBBF24),
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              TextSpan(
+                text: ability.effects.map((e) => e.op).join(', '),
+                style: const TextStyle(
+                  color: Color(0xFF94A3B8),
+                  fontSize: 11,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }).toList();
+  }
+
+  String _timingLabel(TriggerWhen when) {
+    switch (when) {
+      case TriggerWhen.onPlay:
+        return '展開時';
+      case TriggerWhen.onDestroy:
+        return '破壊時';
+      case TriggerWhen.activated:
+        return '起動効果';
+      case TriggerWhen.onDiscard:
+        return '廃棄時';
+    }
+  }
+}
+
+class _StatsRow extends StatelessWidget {
+  final Stats stats;
+  const _StatsRow({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _StatBadge(label: 'ATK', value: stats.atk, color: const Color(0xFFEF4444)),
+        const SizedBox(width: 6),
+        _StatBadge(label: 'DEF', value: stats.def, color: const Color(0xFF3B82F6)),
+        const SizedBox(width: 6),
+        _StatBadge(label: 'HP', value: stats.hp, color: const Color(0xFF22C55E)),
+      ],
+    );
+  }
+}
+
+class _StatBadge extends StatelessWidget {
+  final String label;
+  final int value;
+  final Color color;
+  const _StatBadge({required this.label, required this.value, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withOpacity(0.4)),
+      ),
+      child: Text(
+        '$label $value',
+        style: TextStyle(
+          color: color,
+          fontSize: 10,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButtons extends StatelessWidget {
+  final bool canAct;
+  final String actionLabel;
+  final VoidCallback onConfirm;
+  final VoidCallback onDismiss;
+
+  const _ActionButtons({
+    required this.canAct,
+    required this.actionLabel,
+    required this.onConfirm,
+    required this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (canAct)
+          SizedBox(
+            width: 72,
+            child: ElevatedButton(
+              onPressed: onConfirm,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFFFD700),
+                foregroundColor: Colors.black,
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                textStyle: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              child: Text(actionLabel),
+            ),
+          ),
+        if (canAct) const SizedBox(height: 6),
+        SizedBox(
+          width: 72,
+          child: OutlinedButton(
+            onPressed: onDismiss,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: const Color(0xFF64748B),
+              side: const BorderSide(color: Color(0xFF30363D)),
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              textStyle: const TextStyle(fontSize: 12),
+            ),
+            child: const Text('閉じる'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,3 +30,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/cards/
+    - assets/images/cards/


### PR DESCRIPTION
## Summary

- **カード画像対応**: `CardData` に `String? image` フィールドを追加。YAML に `image: xxx.png` を記載し `assets/images/cards/` に配置するとカードに画像が表示される。画像なしは種別グラデーションにフォールバック。
- **2タップ選択システム**: 1回目タップで選択（ゴールドグロー＋詳細パネルスライドイン）、2回目タップorパネルのボタンでプレイ/発動。空白タップ・「閉じる」で選択解除。
- **ビジュアルポリッシュ**: 濃紺背景・グリッドテクスチャ・ゾーン背景色分け・カードグラデーション・ライフ/スペルのピルHUD・半透明ログパネル。

## Bug fixes included

- `LateInitializationError`: `gameState` を `onLoad()` 内ではなくコンストラクタ時に初期化するよう修正
- **誤カードプレイバグ**: `onTap` クロージャがループ変数 `i` を固定キャプチャしていたため、選択カードと異なるインデックスがプレイされていた。実行時に `instanceId` から正しいインデックスを動的解決するよう修正。

## Test plan

- [ ] `flutter test` — 82テスト全通過
- [ ] 手札カードを1タップ → 詳細パネル表示＆ゴールド枠
- [ ] 同カードを再タップ → 正しくプレイされる
- [ ] 別カードをタップ → 選択が切り替わる
- [ ] 空白タップ → 選択解除
- [ ] `assets/images/cards/` に PNG を置き YAML に `image:` を追記 → 画像表示

🤖 Generated with [Claude Code](https://claude.ai/claude-code)