### PR TITLE
feat: タグシステム拡充 + 汎用カード選択 UI

### DIFF
--- a/docs/CARD_YAML_SPEC.md
+++ b/docs/CARD_YAML_SPEC.md
@@ -106,23 +106,33 @@ pre:
 ### 6.1 カード移動・破壊
 
 ```yaml
-- { op: destroy, target: "choose:self:artifact", count: 1 }
-- { op: move, from: hand, to: grave, target: "choose:self:any", count: 1 }
+# タイプでフィルタリングしてサーチ
 - { op: search, from: deck, to: hand, filter: { type: "domain" }, max: 1 }
+
+# タグでフィルタリングして移動（複数候補 → プレイヤーが選択）
+- { op: move, from: grave, to: hand, filter: { tag: "token" }, count: 1 }
+
+# タグでフィルタリングして破壊（複数候補 → プレイヤーが選択）
+- { op: destroy, target: board, filter: { tag: "weak" }, count: 1 }
 ```
 
-* `from` / `to`: `hand | deck | grave | board | domain | extra`
-* `count`: 数。省略時は可能な限り全て。
-* `target`: 対象記法（後述）。`move` op でも使用可能。
+* `from` / `to` / `target`: `hand | deck | grave | board | domain | extra`
+* `count`: 対象枚数。省略時は 1。
+* `filter`: タグ・タイプ・名前でカードを絞り込む（後述「タグシステム」参照）。
+* **複数候補がある場合はプレイヤーが選択 UI で選択できる**。
 
 ### 6.2 手札操作
 
 ```yaml
 - { op: draw, count: 2 }
-- { op: discard, from: hand, count: 1, selection: choose }
+# filter なし → 先頭から count 枚を自動捨て
+- { op: discard, from: hand, count: 1 }
+# filter あり + 複数候補 → プレイヤーが選択
+- { op: discard, from: hand, count: 1, filter: { tag: "burn" } }
 ```
 
-* `selection`: `choose`（プレイヤー選択）または `random`。**省略時のデフォルトは `choose`**。
+* `filter` を指定した場合、一致するカードが `count` 枚を超えるとプレイヤーが選択する。
+* `filter` を省略した場合は先頭から `count` 枚を自動選択（従来動作）。
 
 ### 6.3 ステータス操作
 
@@ -150,7 +160,76 @@ pre:
 
 ---
 
-## 7. ターゲット記法
+## 7. タグシステム
+
+### タグの定義
+
+カード YAML の `tags` フィールドに任意の文字列タグを複数設定できます。
+
+```yaml
+tags: [warrior, elite, burn]
+```
+
+* タグは大文字・小文字を区別する（`'Warrior'` と `'warrior'` は別物）。
+* タグ名は英数字・アンダースコア・ハイフン推奨。
+* タグ数の上限はなし。
+
+### filter パラメータ
+
+`discard` / `move` / `destroy` / `search` の各 op は `filter` パラメータを受け付けます。
+
+```yaml
+filter:
+  tag: "xxx"      # 指定タグを持つカードのみ対象
+  type: "spell"   # 指定タイプのカードのみ対象（tag と同時使用可能）
+  name: "カード名" # 名前完全一致（tag/type と同時使用可能）
+```
+
+* 複数条件はすべて AND。
+* `filter` を省略した場合はすべてのカードが対象。
+
+### タグによる勝利条件の例
+
+```yaml
+id: spl_daisangen
+name: 大三元の魔法
+type: spell
+tags: [spl_daisangen]
+text: 「白の魔法」「發の魔法」「中の魔法」がそれぞれ3枚以上あること。効果：勝利する。
+version: 1
+abilities:
+  - when: on_play
+    pre:
+      - "count(tag:'spl_haku', zone:'hand:self') >= 3"
+      - "count(tag:'spl_hatsu', zone:'hand:self') >= 3"
+      - "count(tag:'spl_chun', zone:'hand:self') >= 3"
+    effect:
+      - { op: win }
+```
+
+### プレイヤー選択との組み合わせ例
+
+```yaml
+id: spl_purge
+name: 弱者一掃
+type: spell
+tags: [removal]
+text: 手札の「burn」タグのカードを1枚捨て、場の「weak」タグを1体破壊する。
+version: 1
+abilities:
+  - when: on_play
+    pre:
+      - "count(tag:'burn', zone:'hand:self') >= 1"
+      - "count(tag:'weak', zone:'board:self') >= 1"
+    effect:
+      # 複数候補があるとプレイヤーが選択 UI で選ぶ
+      - { op: discard, from: hand, count: 1, filter: { tag: "burn" } }
+      - { op: destroy, target: board, filter: { tag: "weak" }, count: 1 }
+```
+
+---
+
+## 8. ターゲット記法
 
 `"{scope}:{owner}:{selector}"`
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -158,3 +158,46 @@
 | `count(tag:'X', zone:'Y')` | 指定ゾーンの指定タグのカード枚数 |
 
 対応する演算子: `>= <= > < == != && || !`
+
+---
+
+## 14. フィルタシステムとカード選択
+
+### filter パラメータ
+
+`discard`, `move`, `destroy`, `search` の各 op は `filter` パラメータをサポートする。
+
+```yaml
+filter:
+  tag: string    # タグ完全一致
+  type: string   # CardType 文字列完全一致（例: monster, spell）
+  name: string   # カード名完全一致
+```
+
+* 複数キーは AND 条件として評価する。
+* `filter` パラメータ自体を省略した場合はフィルタなし（全カードが対象）。
+
+### タグシステム
+
+* `CardData.tags: List<String>` に任意の文字列タグを設定できる。
+* YAML: `tags: [tagA, tagB, ...]`
+* タグは大文字・小文字を区別する。
+* 数の制限なし。
+
+### 各 op での filter と選択挙動
+
+| op | candidates < count | candidates == count | candidates > count かつ filter あり |
+|---|---|---|---|
+| `discard` | failure | 自動選択して捨て | ChoiceRequest → プレイヤー選択 |
+| `move` | 一致分だけ移動 | 自動移動 | ChoiceRequest → プレイヤー選択 |
+| `destroy` | 一致分だけ破壊（0件なら failure） | 自動破壊 | ChoiceRequest → プレイヤー選択 |
+| `search` | 一致分だけ移動 | 全移動 | 先頭 max 枚を自動移動（選択なし） |
+
+### ChoiceRequest の解決フロー
+
+1. エンジンが `ChoiceRequest` を `GameState.choiceRequest` ValueNotifier にセット
+2. `TriggerService.resolveAll()` が一時停止（`GameResult.pending` を返す）
+3. ゲーム画面が `ChoiceOverlay` を表示し、候補カードを一覧表示
+4. プレイヤーが指定枚数を選択して確定
+5. `TCGGame.resolveChoice()` が選択されたカードに操作を適用
+6. `choiceRequest` をクリアし、`TriggerService.resolveAll()` を再呼び出し

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -17,6 +17,32 @@
 
 ---
 
+## 2026-04-08 - [Feature] タグシステム拡充 + 汎用カード選択 UI の実装
+
+- **判断内容**:
+  - `discard` / `move` / `destroy` op に `filter` パラメータを追加し、タグ・タイプ・名前でカードを絞り込めるようにした
+  - `ChoiceRequest` モデルを再設計（`candidates: List<CardInstance>`, `sourceZone`, `targetZone` を追加。`pendingEffects` は削除）
+  - `GameResult` に `awaitingChoice: bool` フラグと `GameResult.pending()` ファクトリを追加
+  - `TriggerService.resolveAll()` に `awaitingChoice` 検出・一時停止ロジックを追加
+  - `TCGGame.resolveChoice()` を追加し、選択後のトリガー再開を実装
+  - `CardDetailPanel` にタグ Chip 表示を追加
+  - `ChoiceOverlay` ウィジェットを新規作成（候補カードグリッド + 確定ボタン）
+  - `GameScreen` に `ChoiceOverlay` を `ValueListenableBuilder` で接続
+- **理由**: filter なしの op は先頭から自動選択（従来動作）、filter あり + 複数候補の場合のみプレイヤーに選択を委ねる設計にすることで後方互換性を維持しつつ UX を改善
+- **影響範囲**:
+  - `lib/domain/models/choice_request.dart` （再設計）
+  - `lib/domain/models/game_result.dart` （フラグ追加）
+  - `lib/domain/commands/operation_executor.dart` （filter 対応）
+  - `lib/domain/services/trigger_service.dart` （一時停止）
+  - `lib/presentation/game/tcg_game.dart` （resolveChoice 追加）
+  - `lib/ui/widgets/card_detail_panel.dart` （タグ表示）
+  - `lib/ui/widgets/choice_overlay.dart` （新規）
+  - `lib/ui/screens/game_screen.dart` （接続）
+  - `test/domain/commands/operation_executor_test.dart` （テスト15件追加）
+  - `docs/CARD_YAML_SPEC.md` / `docs/SPEC.md` （ドキュメント更新）
+
+---
+
 ## 2025-10-22 00:00 - [Architecture] 3層アーキテクチャ採用
 
 - **判断内容**: Presentation / Domain / Data の 3 層構造を採用

--- a/lib/domain/commands/operation_executor.dart
+++ b/lib/domain/commands/operation_executor.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import '../../core/game_state.dart';
 import '../models/card_data.dart';
 import '../models/card_instance.dart';
+import '../models/choice_request.dart';
 import '../models/game_result.dart';
 import '../models/game_zone.dart';
 import '../services/expression_evaluator.dart';
@@ -62,25 +63,42 @@ class OperationExecutor {
   static GameResult _executeDiscard(GameState state, Map<String, dynamic> params) {
     final from = params['from'] as String? ?? 'hand';
     final count = params['count'] as int? ?? 1;
+    final filter = _parseFilter(params['filter']);
     final logs = <String>[];
 
     if (from != 'hand') {
       return GameResult.failure('discard: only supports from="hand" currently');
     }
 
-    if (state.hand.count < count) {
-      return GameResult.failure('Not enough cards to discard (need $count, have ${state.hand.count})');
+    final candidates = state.hand.where((card) => _matchesFilter(card, filter)).toList();
+
+    if (candidates.length < count) {
+      return GameResult.failure(
+        'Not enough cards to discard (need $count, matched ${candidates.length})',
+      );
     }
 
-    for (int i = 0; i < count; i++) {
-      final card = state.hand.removeAt(0);
-      if (card != null) {
-        state.grave.add(card);
-        
-        for (final ability in card.card.abilities) {
-          if (ability.when == TriggerWhen.onDiscard) {
-            TriggerService.enqueueAbility(state, card, ability);
-          }
+    // filter 指定かつ候補が count より多い場合はプレイヤーに選択を委ねる
+    // filter なし（全手札が対象）の場合は先頭から自動選択（従来動作）
+    if (filter.isNotEmpty && candidates.length > count) {
+      state.choiceRequest.value = ChoiceRequest(
+        type: ChoiceType.discard,
+        count: count,
+        candidates: candidates,
+        sourceZone: from,
+        message: 'フィルタに一致するカードを$count枚選んでください',
+      );
+      return GameResult.pending(logs: ['Awaiting player choice for discard']);
+    }
+
+    // 自動選択（filter なし or ちょうど count 枚一致）
+    for (final card in candidates.take(count).toList()) {
+      state.hand.remove(card);
+      state.grave.add(card);
+
+      for (final ability in card.card.abilities) {
+        if (ability.when == TriggerWhen.onDiscard) {
+          TriggerService.enqueueAbility(state, card, ability);
         }
       }
     }
@@ -92,7 +110,7 @@ class OperationExecutor {
   static GameResult _executeSearch(GameState state, Map<String, dynamic> params) {
     final fromZone = params['from'] as String? ?? 'deck';
     final toZone = params['to'] as String? ?? 'hand';
-    final filter = params['filter'] as Map<String, dynamic>? ?? {};
+    final filter = _parseFilter(params['filter']);
     final maxCount = params['max'] as int? ?? 1;
     final logs = <String>[];
 
@@ -124,6 +142,7 @@ class OperationExecutor {
     final toZone = params['to'] as String?;
     final target = params['target'] as String? ?? 'any';
     final count = params['count'] as int? ?? 1;
+    final filter = _parseFilter(params['filter']);
     final logs = <String>[];
 
     if (fromZone == null || toZone == null) {
@@ -137,27 +156,27 @@ class OperationExecutor {
       return GameResult.failure('Invalid zone in move operation');
     }
 
-    int moved = 0;
-    for (int i = 0; i < count && source.isNotEmpty; i++) {
-      CardInstance? card;
-      
-      switch (target) {
-        case 'top':
-          card = source.removeAt(0);
-          break;
-        case 'bottom':
-          card = source.removeAt(source.count - 1);
-          break;
-        case 'any':
-        default:
-          card = source.removeAt(0);
-          break;
-      }
+    final candidates = source.where((card) => _matchesFilter(card, filter)).toList();
+    final ordered = (target == 'bottom') ? candidates.reversed.toList() : candidates;
 
-      if (card != null) {
-        destination.add(card);
-        moved++;
-      }
+    // filter 指定かつ候補が count より多い場合はプレイヤーに選択を委ねる
+    if (filter.isNotEmpty && ordered.length > count) {
+      state.choiceRequest.value = ChoiceRequest(
+        type: ChoiceType.move,
+        count: count,
+        candidates: ordered,
+        sourceZone: fromZone,
+        targetZone: toZone,
+        message: '移動するカードを$count枚選んでください',
+      );
+      return GameResult.pending(logs: ['Awaiting player choice for move']);
+    }
+
+    int moved = 0;
+    for (int i = 0; i < count && i < ordered.length; i++) {
+      source.remove(ordered[i]);
+      destination.add(ordered[i]);
+      moved++;
     }
 
     logs.add('Moved $moved cards from $fromZone to $toZone');
@@ -166,32 +185,56 @@ class OperationExecutor {
 
   static GameResult _executeDestroy(GameState state, Map<String, dynamic> params) {
     final target = params['target'] as String? ?? 'board';
+    final filter = _parseFilter(params['filter']);
+    final count = params['count'] as int? ?? 1;
     final logs = <String>[];
 
     if (target == 'domain' && state.hasDomain) {
       final domainCard = state.domain.removeAt(0)!;
       state.grave.add(domainCard);
-      
+
       for (final ability in domainCard.card.abilities) {
         if (ability.when == TriggerWhen.onDestroy) {
           TriggerService.enqueueAbility(state, domainCard, ability);
         }
       }
-      
+
       logs.add('Destroyed domain card: ${domainCard.card.name}');
       return GameResult.success(logs: logs);
-    } else if (target == 'board' && state.board.isNotEmpty) {
-      // For now just destroy the first card on the board
-      final boardCard = state.board.removeAt(0)!;
-      state.grave.add(boardCard);
-      
-      for (final ability in boardCard.card.abilities) {
-        if (ability.when == TriggerWhen.onDestroy) {
-          TriggerService.enqueueAbility(state, boardCard, ability);
-        }
+    } else if (state.board.isNotEmpty) {
+      final candidates = state.board.where((card) => _matchesFilter(card, filter)).toList();
+
+      if (candidates.isEmpty) {
+        return GameResult.failure('No valid target to destroy');
       }
-      
-      logs.add('Destroyed board card: ${boardCard.card.name}');
+
+      // filter 指定かつ候補が count より多い場合はプレイヤーに選択を委ねる
+      if (filter.isNotEmpty && candidates.length > count) {
+        state.choiceRequest.value = ChoiceRequest(
+          type: ChoiceType.destroy,
+          count: count,
+          candidates: candidates,
+          sourceZone: 'board',
+          message: '破壊するカードを$count枚選んでください',
+        );
+        return GameResult.pending(logs: ['Awaiting player choice for destroy']);
+      }
+
+      int destroyed = 0;
+      for (int i = 0; i < count && i < candidates.length; i++) {
+        final boardCard = candidates[i];
+        state.board.remove(boardCard);
+        state.grave.add(boardCard);
+
+        for (final ability in boardCard.card.abilities) {
+          if (ability.when == TriggerWhen.onDestroy) {
+            TriggerService.enqueueAbility(state, boardCard, ability);
+          }
+        }
+        destroyed++;
+      }
+
+      logs.add('Destroyed $destroyed cards from board');
       return GameResult.success(logs: logs);
     }
 
@@ -236,7 +279,7 @@ class OperationExecutor {
   static GameResult _executeMill(GameState state, Map<String, dynamic> params) {
     final count = params['count'] as int? ?? 1;
     final logs = <String>[];
-    
+
     int milled = 0;
     for (int i = 0; i < count && state.deck.isNotEmpty; i++) {
       final card = state.deck.removeAt(0);
@@ -259,7 +302,7 @@ class OperationExecutor {
     if (cardId == null) {
       return GameResult.failure('set_domain: missing card parameter');
     }
-    
+
     // この部分は実際にはカードDBから該当カードを探す実装を行う
     return GameResult.failure('set_domain: implementation requires card database lookup');
   }
@@ -284,6 +327,17 @@ class OperationExecutor {
       default:
         return null;
     }
+  }
+
+  /// YAML の filter パラメータを Map に変換する。
+  /// YamlMap の場合も通常の Map として扱えるよう正規化する。
+  static Map<String, dynamic> _parseFilter(dynamic filterParam) {
+    if (filterParam == null) return {};
+    if (filterParam is Map<String, dynamic>) return filterParam;
+    if (filterParam is Map) {
+      return filterParam.map((k, v) => MapEntry(k.toString(), v));
+    }
+    return {};
   }
 
   static bool _matchesFilter(CardInstance card, Map<String, dynamic> filter) {

--- a/lib/domain/models/choice_request.dart
+++ b/lib/domain/models/choice_request.dart
@@ -1,23 +1,32 @@
-
+import './card_instance.dart';
 import './card_data.dart';
-import './game_zone.dart';
 
 enum ChoiceType {
   discard,
+  move,
+  destroy,
 }
 
+/// プレイヤーにカード選択を求めるリクエスト。
+///
+/// エンジンが複数の候補カードを特定し、プレイヤーが選ぶ必要があるときに
+/// [GameState.choiceRequest] にセットされる。
+/// UI は [candidates] を表示し、プレイヤーが [count] 枚選択して確定すると
+/// [TCGGame.resolveChoice] が呼ばれてトリガー解決が再開される。
 class ChoiceRequest {
   final ChoiceType type;
   final int count;
-  final GameZone fromZone;
-  final List<EffectStep> pendingEffects;
+  final List<CardInstance> candidates;
+  final String sourceZone;
+  final String? targetZone;
   final String? message;
 
   ChoiceRequest({
     required this.type,
     required this.count,
-    required this.fromZone,
-    required this.pendingEffects,
+    required this.candidates,
+    required this.sourceZone,
+    this.targetZone,
     this.message,
   });
 }

--- a/lib/domain/models/game_result.dart
+++ b/lib/domain/models/game_result.dart
@@ -2,10 +2,16 @@
 /// 効果解決や処理の結果を表す。
 class GameResult {
   final bool success;
+  final bool awaitingChoice;
   final String? error;
   final List<String> logs;
 
-  const GameResult({required this.success, this.error, this.logs = const []});
+  const GameResult({
+    required this.success,
+    this.awaitingChoice = false,
+    this.error,
+    this.logs = const [],
+  });
 
   factory GameResult.success({List<String> logs = const []}) {
     return GameResult(success: true, logs: logs);
@@ -13,5 +19,10 @@ class GameResult {
 
   factory GameResult.failure(String error, {List<String> logs = const []}) {
     return GameResult(success: false, error: error, logs: logs);
+  }
+
+  /// プレイヤーのカード選択を待っている状態。トリガー解決は一時停止。
+  factory GameResult.pending({List<String> logs = const []}) {
+    return GameResult(success: true, awaitingChoice: true, logs: logs);
   }
 }

--- a/lib/domain/services/trigger_service.dart
+++ b/lib/domain/services/trigger_service.dart
@@ -55,6 +55,12 @@ class TriggerService {
       final result = _resolveTrigger(state, trigger);
       logs.addAll(result.logs);
 
+      if (result.awaitingChoice) {
+        // プレイヤーのカード選択待ち → キューに残りを保持したまま一時停止
+        onUpdate();
+        return GameResult.pending(logs: logs);
+      }
+
       if (!result.success) {
         logs.add('Effect failed: ${result.error}');
       }

--- a/lib/presentation/game/tcg_game.dart
+++ b/lib/presentation/game/tcg_game.dart
@@ -6,7 +6,9 @@ import '../../core/game_state.dart';
 import '../../data/repositories/card_repository.dart';
 import '../../domain/models/card_data.dart';
 import '../../domain/models/card_instance.dart';
+import '../../domain/models/choice_request.dart';
 import '../../domain/models/deck.dart';
+import '../../domain/models/game_zone.dart';
 import '../../domain/services/field_rule.dart';
 import '../../domain/services/trigger_service.dart';
 import '../components/board_component.dart';
@@ -155,6 +157,72 @@ class TCGGame extends FlameGame {
     if (card != null) {
       gameState.hand.add(card);
       gameState.addToLog('ドロー: ${card.card.name}');
+    }
+  }
+
+  /// プレイヤーがカード選択を確定し、ChoiceRequest を解決してトリガー解決を再開する。
+  ///
+  /// [selected] には ChoiceRequest.candidates の中からプレイヤーが選んだカードを渡す。
+  Future<void> resolveChoice(List<CardInstance> selected) async {
+    final request = gameState.choiceRequest.value;
+    if (request == null) return;
+
+    Map<dynamic, dynamic> dummyUpdate() => {};
+
+    switch (request.type) {
+      case ChoiceType.discard:
+        for (final card in selected) {
+          gameState.hand.remove(card);
+          gameState.grave.add(card);
+          for (final ability in card.card.abilities) {
+            if (ability.when == TriggerWhen.onDiscard) {
+              TriggerService.enqueueAbility(gameState, card, ability);
+            }
+          }
+        }
+        gameState.addToLog('Player discarded ${selected.length} card(s)');
+      case ChoiceType.move:
+        final destination = _getZoneByName(request.targetZone ?? 'hand');
+        final source = _getZoneByName(request.sourceZone);
+        if (source != null && destination != null) {
+          for (final card in selected) {
+            source.remove(card);
+            destination.add(card);
+          }
+          gameState.addToLog('Player moved ${selected.length} card(s) to ${request.targetZone}');
+        }
+      case ChoiceType.destroy:
+        for (final card in selected) {
+          gameState.board.remove(card);
+          gameState.grave.add(card);
+          for (final ability in card.card.abilities) {
+            if (ability.when == TriggerWhen.onDestroy) {
+              TriggerService.enqueueAbility(gameState, card, ability);
+            }
+          }
+        }
+        gameState.addToLog('Player destroyed ${selected.length} card(s)');
+    }
+
+    // ChoiceRequest をクリアして UI を閉じる
+    gameState.choiceRequest.value = null;
+
+    // 残りのトリガーを再開
+    final resolveResult = await TriggerService.resolveAll(gameState, dummyUpdate);
+    gameState.actionLog.addAll(resolveResult.logs);
+  }
+
+  /// ゾーン名からゾーンオブジェクトを解決するヘルパー。
+  GameZone? _getZoneByName(String? name) {
+    if (name == null) return null;
+    switch (name.toLowerCase()) {
+      case 'hand': return gameState.hand;
+      case 'deck': return gameState.deck;
+      case 'board': return gameState.board;
+      case 'domain': return gameState.domain;
+      case 'grave': return gameState.grave;
+      case 'extra': return gameState.extra;
+      default: return null;
     }
   }
 

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -2,9 +2,11 @@ import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 
 import '../../domain/models/card_selection_state.dart';
+import '../../domain/models/choice_request.dart';
 import '../../domain/models/deck.dart';
 import '../../presentation/game/tcg_game.dart';
 import '../widgets/card_detail_panel.dart';
+import '../widgets/choice_overlay.dart';
 
 /// ゲームプレイ画面
 ///
@@ -70,6 +72,17 @@ class _GameScreenState extends State<GameScreen> {
                   ),
                 ),
               ),
+            },
+          ),
+          // カード選択オーバーレイ（ChoiceRequest 発生時に表示）
+          ValueListenableBuilder<ChoiceRequest?>(
+            valueListenable: _game.gameState.choiceRequest,
+            builder: (context, request, _) {
+              if (request == null) return const SizedBox.shrink();
+              return ChoiceOverlay(
+                request: request,
+                onConfirm: (selected) => _game.resolveChoice(selected),
+              );
             },
           ),
           // カード詳細パネル（選択時にスライドイン）

--- a/lib/ui/widgets/card_detail_panel.dart
+++ b/lib/ui/widgets/card_detail_panel.dart
@@ -197,6 +197,32 @@ class _CardInfo extends StatelessWidget {
             ),
           ],
         ),
+        if (card.tags.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Wrap(
+            spacing: 4,
+            runSpacing: 2,
+            children: card.tags
+                .map(
+                  (tag) => Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF21262D),
+                      borderRadius: BorderRadius.circular(4),
+                      border: Border.all(color: const Color(0xFF30363D)),
+                    ),
+                    child: Text(
+                      tag,
+                      style: const TextStyle(
+                        color: Color(0xFF8B949E),
+                        fontSize: 10,
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
         if (card.stats != null) ...[
           const SizedBox(height: 6),
           _StatsRow(stats: card.stats!),

--- a/lib/ui/widgets/choice_overlay.dart
+++ b/lib/ui/widgets/choice_overlay.dart
@@ -1,0 +1,295 @@
+// ignore_for_file: deprecated_member_use
+import 'package:flutter/material.dart';
+
+import '../../domain/models/card_data.dart';
+import '../../domain/models/card_instance.dart';
+import '../../domain/models/choice_request.dart';
+import '../theme/game_theme.dart';
+
+/// カード選択 UI オーバーレイ。
+///
+/// エンジンが複数の候補カードからプレイヤーの選択を必要とするときに表示される。
+/// [request.candidates] を一覧表示し、[request.count] 枚選択して確定ボタンを押すと
+/// [onConfirm] がコールされる。
+class ChoiceOverlay extends StatefulWidget {
+  final ChoiceRequest request;
+  final void Function(List<CardInstance> selected) onConfirm;
+
+  const ChoiceOverlay({
+    super.key,
+    required this.request,
+    required this.onConfirm,
+  });
+
+  @override
+  State<ChoiceOverlay> createState() => _ChoiceOverlayState();
+}
+
+class _ChoiceOverlayState extends State<ChoiceOverlay> {
+  // 選択済みカードの instanceId を挿入順に管理するリスト
+  final List<String> _selectedIds = [];
+
+  void _toggleCard(CardInstance card) {
+    setState(() {
+      if (_selectedIds.contains(card.instanceId)) {
+        _selectedIds.remove(card.instanceId);
+      } else {
+        if (_selectedIds.length >= widget.request.count) {
+          // 上限に達したら最古の選択を解除して新しいカードを選択
+          _selectedIds.removeAt(0);
+        }
+        _selectedIds.add(card.instanceId);
+      }
+    });
+  }
+
+  bool get _isConfirmEnabled => _selectedIds.length == widget.request.count;
+
+  void _handleConfirm() {
+    final selected = widget.request.candidates
+        .where((c) => _selectedIds.contains(c.instanceId))
+        .toList();
+    widget.onConfirm(selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Material(
+        color: Colors.black.withOpacity(0.75),
+        child: SafeArea(
+          child: Column(
+            children: [
+              const SizedBox(height: 24),
+              // メッセージ
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Text(
+                  widget.request.message ?? 'カードを${widget.request.count}枚選んでください',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 8),
+              // 選択状況
+              Text(
+                '${_selectedIds.length} / ${widget.request.count} 枚選択中',
+                style: TextStyle(
+                  color: _isConfirmEnabled
+                      ? GameTheme.selectionGlow
+                      : const Color(0xFF8B949E),
+                  fontSize: 14,
+                ),
+              ),
+              const SizedBox(height: 16),
+              // 候補カードグリッド
+              Expanded(
+                child: GridView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    childAspectRatio: 0.72,
+                    crossAxisSpacing: 12,
+                    mainAxisSpacing: 12,
+                  ),
+                  itemCount: widget.request.candidates.length,
+                  itemBuilder: (context, index) {
+                    final card = widget.request.candidates[index];
+                    final isSelected = _selectedIds.contains(card.instanceId);
+                    return _CandidateCard(
+                      card: card,
+                      isSelected: isSelected,
+                      onTap: () => _toggleCard(card),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 16),
+              // 確定ボタン
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _isConfirmEnabled ? _handleConfirm : null,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: GameTheme.selectionGlow,
+                      foregroundColor: Colors.black,
+                      disabledBackgroundColor: const Color(0xFF30363D),
+                      disabledForegroundColor: const Color(0xFF8B949E),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: Text(
+                      '確定 (${_selectedIds.length}/${widget.request.count})',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CandidateCard extends StatelessWidget {
+  final CardInstance card;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _CandidateCard({
+    required this.card,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final gradColors = GameTheme.cardGradient(card.card.type);
+    final accentColor = GameTheme.cardAccentColor(card.card.type);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: gradColors,
+          ),
+          border: Border.all(
+            color: isSelected
+                ? GameTheme.selectionBorder
+                : accentColor.withOpacity(0.4),
+            width: isSelected ? 3 : 1.5,
+          ),
+          boxShadow: isSelected
+              ? [
+                  BoxShadow(
+                    color: GameTheme.selectionGlow.withOpacity(0.5),
+                    blurRadius: 12,
+                    spreadRadius: 2,
+                  )
+                ]
+              : [],
+        ),
+        child: Stack(
+          children: [
+            // カード画像またはプレースホルダー
+            if (card.card.image != null)
+              Positioned.fill(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8.5),
+                  child: Image.asset(
+                    'assets/images/cards/${card.card.image}',
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) => _buildPlaceholder(gradColors),
+                  ),
+                ),
+              )
+            else
+              Positioned.fill(child: _buildPlaceholder(gradColors)),
+            // カード名（下部）
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                decoration: BoxDecoration(
+                  borderRadius: const BorderRadius.only(
+                    bottomLeft: Radius.circular(8.5),
+                    bottomRight: Radius.circular(8.5),
+                  ),
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [Colors.transparent, Colors.black.withOpacity(0.8)],
+                  ),
+                ),
+                child: Text(
+                  card.card.name,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 11,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
+            // 選択チェックマーク
+            if (isSelected)
+              Positioned(
+                top: 6,
+                right: 6,
+                child: Container(
+                  width: 24,
+                  height: 24,
+                  decoration: const BoxDecoration(
+                    color: GameTheme.selectionGlow,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.check,
+                    color: Colors.black,
+                    size: 16,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlaceholder(List<Color> gradColors) {
+    return Center(
+      child: Text(
+        _typeIcon(card.card.type),
+        style: TextStyle(
+          fontSize: 36,
+          color: gradColors[1].withOpacity(0.7),
+        ),
+      ),
+    );
+  }
+
+  String _typeIcon(CardType type) {
+    switch (type) {
+      case CardType.monster:
+        return '⚔';
+      case CardType.ritual:
+        return '✦';
+      case CardType.spell:
+        return '✦';
+      case CardType.arcane:
+        return '✧';
+      case CardType.artifact:
+        return '⬡';
+      case CardType.relic:
+        return '◈';
+      case CardType.equip:
+        return '🛡';
+      case CardType.domain:
+        return '◉';
+    }
+  }
+}

--- a/test/domain/commands/operation_executor_test.dart
+++ b/test/domain/commands/operation_executor_test.dart
@@ -11,6 +11,13 @@ CardInstance _makeCard(String id, CardType type, {List<Ability> abilities = cons
   );
 }
 
+CardInstance _makeTaggedCard(String id, CardType type, List<String> tags) {
+  return CardInstance(
+    card: CardData(id: id, name: id, type: type, tags: tags),
+    instanceId: id,
+  );
+}
+
 EffectStep _op(String op, [Map<String, dynamic> params = const {}]) {
   return EffectStep(op: op, params: params);
 }
@@ -227,6 +234,162 @@ void main() {
           state, _op('unknown_op'));
 
       expect(result.success, isFalse);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  group('op: discard (filter)', () {
+    test('filter tag が1枚だけ一致 → 自動で grave に移動する', () {
+      state.hand.add(_makeTaggedCard('h1', CardType.spell, ['burn']));
+      state.hand.add(_makeTaggedCard('h2', CardType.spell, []));
+
+      OperationExecutor.executeOperation(
+          state, _op('discard', {'from': 'hand', 'count': 1, 'filter': {'tag': 'burn'}}));
+
+      expect(state.grave.cards.first.card.id, 'h1');
+    });
+
+    test('filter tag が1枚だけ一致 → hand から消える', () {
+      state.hand.add(_makeTaggedCard('h1', CardType.spell, ['burn']));
+      state.hand.add(_makeTaggedCard('h2', CardType.spell, []));
+
+      OperationExecutor.executeOperation(
+          state, _op('discard', {'from': 'hand', 'count': 1, 'filter': {'tag': 'burn'}}));
+
+      expect(state.hand.count, 1);
+    });
+
+    test('filter tag に一致するカードが不足する場合は failure を返す', () {
+      state.hand.add(_makeTaggedCard('h1', CardType.spell, ['fire']));
+
+      final result = OperationExecutor.executeOperation(
+          state, _op('discard', {'from': 'hand', 'count': 1, 'filter': {'tag': 'burn'}}));
+
+      expect(result.success, isFalse);
+    });
+
+    test('filter なしの discard は従来通り動作する', () {
+      state.hand.add(_makeCard('h1', CardType.spell));
+      state.hand.add(_makeCard('h2', CardType.spell));
+
+      OperationExecutor.executeOperation(
+          state, _op('discard', {'from': 'hand', 'count': 1}));
+
+      expect(state.grave.count, 1);
+    });
+
+    test('filter 複数候補 → choiceRequest が設定される', () {
+      state.hand.add(_makeTaggedCard('h1', CardType.spell, ['burn']));
+      state.hand.add(_makeTaggedCard('h2', CardType.spell, ['burn']));
+
+      OperationExecutor.executeOperation(
+          state, _op('discard', {'from': 'hand', 'count': 1, 'filter': {'tag': 'burn'}}));
+
+      expect(state.choiceRequest.value, isNotNull);
+    });
+
+    test('filter 複数候補 → awaitingChoice が true', () {
+      state.hand.add(_makeTaggedCard('h1', CardType.spell, ['burn']));
+      state.hand.add(_makeTaggedCard('h2', CardType.spell, ['burn']));
+
+      final result = OperationExecutor.executeOperation(
+          state, _op('discard', {'from': 'hand', 'count': 1, 'filter': {'tag': 'burn'}}));
+
+      expect(result.awaitingChoice, isTrue);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  group('op: move (filter)', () {
+    test('filter tag が1枚一致 → 自動移動する', () {
+      state.grave.add(_makeTaggedCard('g1', CardType.spell, ['token']));
+      state.grave.add(_makeTaggedCard('g2', CardType.spell, []));
+
+      OperationExecutor.executeOperation(
+          state, _op('move', {'from': 'grave', 'to': 'hand', 'count': 1, 'filter': {'tag': 'token'}}));
+
+      expect(state.hand.cards.first.card.id, 'g1');
+    });
+
+    test('filter tag が1枚一致 → 元ゾーンから消える', () {
+      state.grave.add(_makeTaggedCard('g1', CardType.spell, ['token']));
+      state.grave.add(_makeTaggedCard('g2', CardType.spell, []));
+
+      OperationExecutor.executeOperation(
+          state, _op('move', {'from': 'grave', 'to': 'hand', 'count': 1, 'filter': {'tag': 'token'}}));
+
+      expect(state.grave.count, 1);
+    });
+
+    test('filter tag に一致しないカードは移動されない', () {
+      state.grave.add(_makeTaggedCard('g1', CardType.spell, ['fire']));
+
+      OperationExecutor.executeOperation(
+          state, _op('move', {'from': 'grave', 'to': 'hand', 'count': 1, 'filter': {'tag': 'token'}}));
+
+      expect(state.hand.count, 0);
+    });
+
+    test('filter 複数候補 → choiceRequest が設定される', () {
+      state.grave.add(_makeTaggedCard('g1', CardType.spell, ['token']));
+      state.grave.add(_makeTaggedCard('g2', CardType.spell, ['token']));
+
+      OperationExecutor.executeOperation(
+          state, _op('move', {'from': 'grave', 'to': 'hand', 'count': 1, 'filter': {'tag': 'token'}}));
+
+      expect(state.choiceRequest.value, isNotNull);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  group('op: destroy (filter)', () {
+    test('filter tag が1枚一致 → 自動破壊される', () {
+      state.board.add(_makeTaggedCard('b1', CardType.monster, ['weak']));
+      state.board.add(_makeTaggedCard('b2', CardType.monster, []));
+
+      OperationExecutor.executeOperation(
+          state, _op('destroy', {'target': 'board', 'filter': {'tag': 'weak'}}));
+
+      expect(state.grave.cards.first.card.id, 'b1');
+    });
+
+    test('filter tag が1枚一致 → board から消える', () {
+      state.board.add(_makeTaggedCard('b1', CardType.monster, ['weak']));
+      state.board.add(_makeTaggedCard('b2', CardType.monster, []));
+
+      OperationExecutor.executeOperation(
+          state, _op('destroy', {'target': 'board', 'filter': {'tag': 'weak'}}));
+
+      expect(state.board.count, 1);
+    });
+
+    test('filter tag に一致するカードがない場合は failure を返す', () {
+      state.board.add(_makeTaggedCard('b1', CardType.monster, ['strong']));
+
+      final result = OperationExecutor.executeOperation(
+          state, _op('destroy', {'target': 'board', 'filter': {'tag': 'weak'}}));
+
+      expect(result.success, isFalse);
+    });
+
+    test('filter 複数候補 → choiceRequest が設定される', () {
+      state.board.add(_makeTaggedCard('b1', CardType.monster, ['weak']));
+      state.board.add(_makeTaggedCard('b2', CardType.monster, ['weak']));
+
+      OperationExecutor.executeOperation(
+          state, _op('destroy', {'target': 'board', 'count': 1, 'filter': {'tag': 'weak'}}));
+
+      expect(state.choiceRequest.value, isNotNull);
+    });
+
+    test('count=2 で filter 一致の2枚が破壊される', () {
+      state.board.add(_makeTaggedCard('b1', CardType.monster, ['weak']));
+      state.board.add(_makeTaggedCard('b2', CardType.monster, ['weak']));
+
+      OperationExecutor.executeOperation(
+          state, _op('destroy', {'target': 'board', 'count': 2, 'filter': {'tag': 'weak'}}));
+
+      expect(state.grave.count, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

- `discard` / `move` / `destroy` op に `filter` パラメータ（tag/type/name）を追加し、タグベースの条件でカードを絞り込めるようにした
- filter あり + 複数候補時は `ChoiceRequest` を発行してプレイヤーにカードを選ばせる汎用選択 UI を実装
- `CardDetailPanel` にタグ Chip 表示を追加

## 変更内容

### Domain 層
- `ChoiceRequest` モデルを再設計（`candidates`, `sourceZone`, `targetZone`）
- `GameResult.pending()` を追加し TriggerService の一時停止に対応
- `TriggerService.resolveAll()` が `awaitingChoice` 検出時に pause
- `TCGGame.resolveChoice()` で選択後のトリガー解決を再開

### UI 層
- `CardDetailPanel`：タグを小さな Chip として表示
- `ChoiceOverlay`（新規）：候補カードのグリッド表示 + 確定ボタン（選択数達成で有効化）
- `GameScreen`：`choiceRequest` ValueNotifier を監視して `ChoiceOverlay` を表示

## Test plan
- [x] `flutter test` 全97件 green（新規テスト15件追加）
- [ ] カードをタップしてタグが Chip 表示されることを確認
- [ ] タグ filter のある効果をプレイして ChoiceOverlay が表示されることを確認
- [ ] カードを選択・確定して効果が正常に適用されることを確認
- [ ] 既存 YAML カード（spl_daisangen 等）が引き続き正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)