### PR TITLE
feat: activated 能力に once_per_turn フラグを追加

### DIFF
--- a/docs/CARD_YAML_SPEC.md
+++ b/docs/CARD_YAML_SPEC.md
@@ -64,7 +64,7 @@ abilities:                    # 任意。0個以上
 | `on_play` | 手札からプレイした直後（サーチ・移動では発火しない） |
 | `on_destroy` | hp ≤ 0 または `destroy` op により破壊された直後 |
 | `on_discard` | 手札から捨て札に置かれた直後 |
-| `activated` | プレイヤーが手動で発動（**1ターン1度制限**はエンジンが強制） |
+| `activated` | プレイヤーが手動で発動。`once_per_turn: true`（省略時デフォルト）でエンジンが1ターン1度を強制。`once_per_turn: false` で無制限。 |
 
 > MVP スコープ外（使用不可）: `on_enter` / `static` / `on_draw` / `on_domain_set`
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -123,7 +123,8 @@
 
 ## 11. `activated` 能力の制限
 
-- `activated` 能力は **1ターンに1度** のみ発動できる（エンジン強制）。
+- `activated` 能力は `once_per_turn: true`（省略時デフォルト）の場合、**1ターンに1度** のみ発動できる（エンジン強制）。
+- `once_per_turn: false` の場合、コストが払えれば何度でも発動できる。
 - `GameState` の `activatedThisTurn: Set<String>` にカードの `instanceId` を記録する。
 - ドローフェイズ開始時に `activatedThisTurn` をクリアする。
 

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -83,3 +83,10 @@
 - **理由**: カードビジュアルの貧弱さとタップ即プレイの UX 問題を解消し、TCG らしいカッコいい画面を実現するため。
 - **影響範囲**: `lib/domain/models/card_data.dart`, `lib/domain/models/card_selection_state.dart`（新規）, `lib/core/game_state.dart`, `lib/presentation/components/card_component.dart`, `lib/presentation/components/board_component.dart`, `lib/ui/screens/game_screen.dart`, `lib/ui/theme/game_theme.dart`（新規）, `lib/ui/widgets/card_detail_panel.dart`（新規）, `pubspec.yaml`
 - **ADR**: なし（UI 改善のため）
+
+## 2026-04-08 - [Feature] activated 能力の発動制限をカードごとに設定可能に変更
+
+- **判断内容**: `Ability` クラスに `oncePerTurn` フィールド（bool, デフォルト `true`）を追加。YAML の `once_per_turn` フィールドで制御。エンジンの1ターン1度強制を `oncePerTurn: true` のカードのみに限定。
+- **理由**: カード効果として「1ターン1度」だけでなく「コストが払えれば何度でも」発動できる activated 能力を設計できるよう拡張するため。
+- **影響範囲**: `lib/domain/models/card_data.dart`, `lib/data/repositories/card_repository.dart`, `lib/presentation/game/tcg_game.dart`, `docs/SPEC.md`, `docs/CARD_YAML_SPEC.md`, `test/data/card_repository_test.dart`, `test/domain/services/activate_once_per_turn_test.dart`（新規）
+- **ADR**: なし

--- a/lib/data/repositories/card_repository.dart
+++ b/lib/data/repositories/card_repository.dart
@@ -109,11 +109,13 @@ class CardRepository {
           }
           
           final effects = _parseEffects(abilityData['effect']);
+          final oncePerTurn = abilityData['once_per_turn'] as bool? ?? true;
 
           abilities.add(Ability(
             when: when,
             pre: pre,
             effects: effects,
+            oncePerTurn: oncePerTurn,
           ));
         }
       }

--- a/lib/domain/models/card_data.dart
+++ b/lib/domain/models/card_data.dart
@@ -52,10 +52,15 @@ class Ability {
   final List<String>? pre;
   final List<EffectStep> effects;
 
+  /// true の場合、1ターンに1度のみ発動できる（デフォルト）。
+  /// false の場合、コストが払えれば何度でも発動できる。
+  final bool oncePerTurn;
+
   const Ability({
     required this.when,
     this.pre,
     required this.effects,
+    this.oncePerTurn = true,
   });
 }
 

--- a/lib/presentation/game/tcg_game.dart
+++ b/lib/presentation/game/tcg_game.dart
@@ -175,19 +175,22 @@ class TCGGame extends FlameGame {
       return;
     }
 
-    // 1ターン1度制限チェック
-    if (gameState.activatedThisTurn.contains(card.instanceId)) {
+    // MVPでは最初に見つかった効果のみを発動
+    final abilityToActivate = activatedAbilities.first;
+
+    // 1ターン1度制限チェック（oncePerTurn が true の場合のみ）
+    if (abilityToActivate.oncePerTurn &&
+        gameState.activatedThisTurn.contains(card.instanceId)) {
       gameState.addToLog('${card.card.name} はすでにこのターン発動済みです。');
       return;
     }
 
     gameState.addToLog('${card.card.name} を起動...');
 
-    // MVPでは最初に見つかった効果のみを発動
-    final abilityToActivate = activatedAbilities.first;
-
-    // 使用済みとして記録
-    gameState.activatedThisTurn.add(card.instanceId);
+    // 使用済みとして記録（oncePerTurn が true の場合のみ）
+    if (abilityToActivate.oncePerTurn) {
+      gameState.activatedThisTurn.add(card.instanceId);
+    }
 
     // トリガーサービスにアビリティをエンキュー
     TriggerService.enqueueAbility(gameState, card, abilityToActivate);

--- a/test/data/card_repository_test.dart
+++ b/test/data/card_repository_test.dart
@@ -188,5 +188,48 @@ void main() {
       // Assert
       expect(card!.abilities, isEmpty);
     });
+
+    test('once_per_turn: false の activated 能力は oncePerTurn が false になる', () {
+      // Arrange
+      const String cardYaml = '''
+      id: 'ar002'
+      name: 'Unlimited Artifact'
+      type: 'artifact'
+      version: 1
+      abilities:
+        - when: 'activated'
+          once_per_turn: false
+          effect:
+            - op: 'draw'
+              count: 1
+      ''';
+
+      // Act
+      final card = CardRepository.parseCard(cardYaml);
+
+      // Assert
+      expect(card!.abilities.first.oncePerTurn, isFalse);
+    });
+
+    test('once_per_turn を省略した activated 能力は oncePerTurn がデフォルト true になる', () {
+      // Arrange
+      const String cardYaml = '''
+      id: 'ar003'
+      name: 'Default Artifact'
+      type: 'artifact'
+      version: 1
+      abilities:
+        - when: 'activated'
+          effect:
+            - op: 'draw'
+              count: 1
+      ''';
+
+      // Act
+      final card = CardRepository.parseCard(cardYaml);
+
+      // Assert
+      expect(card!.abilities.first.oncePerTurn, isTrue);
+    });
   });
 }

--- a/test/domain/services/activate_once_per_turn_test.dart
+++ b/test/domain/services/activate_once_per_turn_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solitcg/core/game_state.dart';
+import 'package:solitcg/domain/models/card_data.dart';
+import 'package:solitcg/domain/models/card_instance.dart';
+
+void main() {
+  late GameState state;
+  late CardInstance card;
+
+  setUp(() {
+    state = GameState();
+    card = CardInstance(
+      card: const CardData(id: 'art001', name: 'Test Artifact', type: CardType.artifact),
+      instanceId: 'art001-1',
+    );
+  });
+
+  group('activated 能力の once_per_turn 制限', () {
+    test('oncePerTurn: true のカードは activatedThisTurn 登録後に制限が発動する', () {
+      final ability = Ability(
+        when: TriggerWhen.activated,
+        effects: const [],
+        oncePerTurn: true,
+      );
+
+      // 1回目: まだ登録されていないので通過できる
+      final blockedBefore = ability.oncePerTurn &&
+          state.activatedThisTurn.contains(card.instanceId);
+      expect(blockedBefore, isFalse);
+
+      // 使用済みとして記録
+      state.activatedThisTurn.add(card.instanceId);
+
+      // 2回目: 制限により blocked になる
+      final blockedAfter = ability.oncePerTurn &&
+          state.activatedThisTurn.contains(card.instanceId);
+      expect(blockedAfter, isTrue);
+    });
+
+    test('oncePerTurn: false のカードは activatedThisTurn に登録されても制限されない', () {
+      final ability = Ability(
+        when: TriggerWhen.activated,
+        effects: const [],
+        oncePerTurn: false,
+      );
+
+      // 使用済みとして仮登録（実際は登録されないが念のため確認）
+      state.activatedThisTurn.add(card.instanceId);
+
+      // oncePerTurn: false なので常に blocked にならない
+      final blocked = ability.oncePerTurn &&
+          state.activatedThisTurn.contains(card.instanceId);
+      expect(blocked, isFalse);
+    });
+
+    test('ドローフェイズで activatedThisTurn がクリアされると制限がリセットされる', () {
+      state.activatedThisTurn.add(card.instanceId);
+      expect(state.activatedThisTurn.contains(card.instanceId), isTrue);
+
+      // ドローフェイズのリセット相当
+      state.activatedThisTurn.clear();
+
+      expect(state.activatedThisTurn.contains(card.instanceId), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- `Ability` クラスに `oncePerTurn` フィールド（bool, デフォルト `true`）を追加
- YAML カード定義で `once_per_turn: false` を指定することで、コストが払えれば何度でも発動できる `activated` 能力を設計可能に
- 既存カードは `once_per_turn` 省略時に `true` 扱いのため後方互換を維持

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `lib/domain/models/card_data.dart` | `Ability.oncePerTurn` フィールド追加 |
| `lib/data/repositories/card_repository.dart` | `once_per_turn` YAML フィールドをパース |
| `lib/presentation/game/tcg_game.dart` | ability 選択後にフラグを参照する順序に修正 |
| `docs/SPEC.md` / `docs/CARD_YAML_SPEC.md` | ルール記述を更新 |
| `docs/audit_log.md` | 設計変更を記録 |
| `test/data/card_repository_test.dart` | `once_per_turn` パーステストを追加 |
| `test/domain/services/activate_once_per_turn_test.dart` | 新規テスト（制限あり・なし・リセット） |

## YAML 使用例

\`\`\`yaml
# 1ターン1度（省略時デフォルト）
- when: activated
  effect:
    - { op: draw, count: 1 }

# 何度でも発動可
- when: activated
  once_per_turn: false
  effect:
    - { op: draw, count: 1 }
\`\`\`

## Test plan

- [ ] \`flutter test test/data/card_repository_test.dart\` — パーステスト通過確認
- [ ] \`flutter test test/domain/services/activate_once_per_turn_test.dart\` — 制限ロジックテスト通過確認
- [ ] \`once_per_turn: true\` のカードを盤面で2回タップ → 2回目は「発動済み」メッセージが出ること
- [ ] \`once_per_turn: false\` のカードを盤面で複数回タップ → 毎回効果が発動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)