### PR TITLE
feat: 水力発電所カード追加（汎用カウンター + on_spell_played トリガー）

### DIFF
--- a/assets/cards/dmn_suiryoku_001.yaml
+++ b/assets/cards/dmn_suiryoku_001.yaml
@@ -1,0 +1,26 @@
+id: dmn_suiryoku_001
+name: 水力発電所
+type: domain
+tags: [counter, energy]
+text: spellが発動されるたびに、このカードにカウンターを一つのせる。カウンターが四つになったら、カウンターを全て取り除き、カードを一枚引く。
+version: 1
+
+domain:
+  unique: true
+
+abilities:
+  # spell play 時にカウンターを +1
+  - when: on_spell_played
+    once_per_turn: false
+    effect:
+      - { op: add_counter, key: spell_count, amount: 1 }
+
+  # spell play 時にカウンターが4以上ならリセットして1枚引く
+  # FIFO 解決により上のアビリティ（add_counter）が先に解決される
+  - when: on_spell_played
+    once_per_turn: false
+    pre:
+      - "self.counter('spell_count') >= 4"
+    effect:
+      - { op: remove_counter, key: spell_count }
+      - { op: draw, count: 1 }

--- a/assets/cards/index.yaml
+++ b/assets/cards/index.yaml
@@ -17,3 +17,4 @@ cards:
   - monster_robot.yaml
   - mon_crystal_looters_001.yaml
   - spl_mining_gem.yaml
+  - dmn_suiryoku_001.yaml

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -31,6 +31,30 @@
 
 ---
 
+## 2026-04-09 - [Feature] 水力発電所カード追加（汎用カウンター + on_spell_played トリガー）
+
+- **判断内容**:
+  - `TriggerWhen.onSpellPlayed` を追加し、domain カードが spell/arcane のプレイを購読できるようにした
+  - `OperationExecutor` に `add_counter` / `remove_counter` op を追加。`CardInstance.metadata` に per-card カウンターを格納する
+  - `OperationExecutor.executeOperation` に `{CardInstance? source}` パラメータを追加し、トリガー発生元カードを effect 実行時に参照できるようにした
+  - `ExpressionEvaluator` に `{CardInstance? self}` パラメータを追加し、`self.counter('key')` 式で発生元カードのメタデータを参照できるようにした
+  - `TriggerService._resolveTrigger` で `trigger.source` を `executeOperation` と `evaluate` に伝播するよう変更
+  - `FieldRule.playCard` の spell/arcane ブランチで、domain カードの `onSpellPlayed` アビリティをキューに追加する処理を実装
+  - カード定義 `assets/cards/dmn_suiryoku_001.yaml` を新規作成（2アビリティ FIFO アプローチ: spell play → add_counter、条件付き remove_counter + draw）
+- **理由**:
+  - 「spell が発動されるたびにカウンターを積み、4つで draw」という効果を既存エンジンで表現するために、per-card カウンターシステムと spell 監視トリガーが必要だった
+  - 2アビリティアプローチ（add_counter と条件付き draw を別アビリティに分割）を採用した理由：FIFO 解決順序により ability1（add_counter）が先に解決され、ability2 の pre 条件（`>= 4`）が正しく評価されることが保証されるため
+- **影響範囲**:
+  - `lib/domain/models/card_data.dart`（enum 拡張）
+  - `lib/data/repositories/card_repository.dart`（parse 追加）
+  - `lib/domain/services/expression_evaluator.dart`（self パラメータ追加）
+  - `lib/domain/commands/operation_executor.dart`（source パラメータ + 新 op）
+  - `lib/domain/services/trigger_service.dart`（source 伝播 + enum 対応）
+  - `lib/domain/services/field_rule.dart`（onSpellPlayed 通知）
+  - `assets/cards/dmn_suiryoku_001.yaml`（新規）
+  - `assets/cards/index.yaml`（エントリ追加）
+- **ADR**: なし（既存アーキテクチャの自然な拡張）
+
 ## 2026-04-08 - [Feature] タグシステム拡充 + 汎用カード選択 UI の実装
 
 - **判断内容**:

--- a/lib/data/repositories/card_repository.dart
+++ b/lib/data/repositories/card_repository.dart
@@ -39,6 +39,8 @@ class CardRepository {
         return TriggerWhen.activated;
       case 'on_discard':
         return TriggerWhen.onDiscard;
+      case 'on_spell_played':
+        return TriggerWhen.onSpellPlayed;
       // MVP スコープ外: static / on_draw / on_enter / on_domain_set は無視
       default:
         return null;

--- a/lib/domain/commands/operation_executor.dart
+++ b/lib/domain/commands/operation_executor.dart
@@ -10,7 +10,8 @@ import '../services/trigger_service.dart';
 import './draw_card_command.dart';
 
 class OperationExecutor {
-  static GameResult executeOperation(GameState state, EffectStep effect) {
+  static GameResult executeOperation(GameState state, EffectStep effect,
+      {CardInstance? source}) {
     try {
       switch (effect.op) {
         case 'require':
@@ -38,6 +39,10 @@ class OperationExecutor {
           return _executeSummon(state, effect.params);
         case 'set_domain':
           return _executeSetDomain(state, effect.params);
+        case 'add_counter':
+          return _executeAddCounter(state, effect.params, source);
+        case 'remove_counter':
+          return _executeRemoveCounter(state, effect.params, source);
         default:
           return GameResult.failure('Unknown operation: ${effect.op}');
       }
@@ -311,6 +316,31 @@ class OperationExecutor {
 
     // この部分は実際にはカードDBから該当カードを探す実装を行う
     return GameResult.failure('set_domain: implementation requires card database lookup');
+  }
+
+  static GameResult _executeAddCounter(
+      GameState state, Map<String, dynamic> params, CardInstance? source) {
+    if (source == null) {
+      return GameResult.failure('add_counter: source card is required');
+    }
+    final key = params['key'] as String? ?? 'counter';
+    final amount = params['amount'] as int? ?? 1;
+    final current = (source.metadata[key] as int?) ?? 0;
+    source.metadata[key] = current + amount;
+    return GameResult.success(logs: [
+      'Added $amount to counter "$key" on ${source.card.name} (now ${current + amount})'
+    ]);
+  }
+
+  static GameResult _executeRemoveCounter(
+      GameState state, Map<String, dynamic> params, CardInstance? source) {
+    if (source == null) {
+      return GameResult.failure('remove_counter: source card is required');
+    }
+    final key = params['key'] as String? ?? 'counter';
+    source.metadata[key] = 0;
+    return GameResult.success(
+        logs: ['Reset counter "$key" on ${source.card.name} to 0']);
   }
 
   static GameZone? _getZoneByName(GameState state, String zoneName) {

--- a/lib/domain/models/card_data.dart
+++ b/lib/domain/models/card_data.dart
@@ -3,7 +3,7 @@ enum CardType { monster, ritual, spell, arcane, artifact, relic, equip, domain }
 
 /// アビリティの発動タイミング。
 /// MVP スコープ: on_play / on_destroy / on_discard / activated の4種のみ。
-enum TriggerWhen { onPlay, onDestroy, activated, onDiscard }
+enum TriggerWhen { onPlay, onDestroy, activated, onDiscard, onSpellPlayed }
 
 /// 攻撃力・防御力・HP を保持するステータス。
 /// atk / def は効果参照用の任意フィールド（省略時は 0）。

--- a/lib/domain/services/expression_evaluator.dart
+++ b/lib/domain/services/expression_evaluator.dart
@@ -1,24 +1,26 @@
 import '../../core/game_state.dart';
+import '../models/card_instance.dart';
 import '../models/game_zone.dart';
 
 /// 文字列表現を評価して true/false を返す簡易式評価機。
 class ExpressionEvaluator {
   /// 与えられた式を評価する。解析に失敗した場合は false を返す。
-  static bool evaluate(GameState state, String expression) {
+  /// [self] にトリガー発生元のカードを渡すと self.counter('key') 式が評価できる。
+  static bool evaluate(GameState state, String expression, {CardInstance? self}) {
     try {
-      return _parseExpression(state, expression.trim());
+      return _parseExpression(state, expression.trim(), self: self);
     } catch (e) {
       return false;
     }
   }
 
   /// シンプルな比較式を解析して評価する。
-  static bool _parseExpression(GameState state, String expr) {
+  static bool _parseExpression(GameState state, String expr, {CardInstance? self}) {
     if (expr.contains('>=')) {
       final parts = expr.split('>=').map((e) => e.trim()).toList();
       if (parts.length == 2) {
-        final left = _evaluateValue(state, parts[0]);
-        final right = _evaluateValue(state, parts[1]);
+        final left = _evaluateValue(state, parts[0], self: self);
+        final right = _evaluateValue(state, parts[1], self: self);
         return left >= right;
       }
     }
@@ -26,8 +28,8 @@ class ExpressionEvaluator {
     if (expr.contains('<=')) {
       final parts = expr.split('<=').map((e) => e.trim()).toList();
       if (parts.length == 2) {
-        final left = _evaluateValue(state, parts[0]);
-        final right = _evaluateValue(state, parts[1]);
+        final left = _evaluateValue(state, parts[0], self: self);
+        final right = _evaluateValue(state, parts[1], self: self);
         return left <= right;
       }
     }
@@ -35,8 +37,8 @@ class ExpressionEvaluator {
     if (expr.contains('>')) {
       final parts = expr.split('>').map((e) => e.trim()).toList();
       if (parts.length == 2) {
-        final left = _evaluateValue(state, parts[0]);
-        final right = _evaluateValue(state, parts[1]);
+        final left = _evaluateValue(state, parts[0], self: self);
+        final right = _evaluateValue(state, parts[1], self: self);
         return left > right;
       }
     }
@@ -44,8 +46,8 @@ class ExpressionEvaluator {
     if (expr.contains('<')) {
       final parts = expr.split('<').map((e) => e.trim()).toList();
       if (parts.length == 2) {
-        final left = _evaluateValue(state, parts[0]);
-        final right = _evaluateValue(state, parts[1]);
+        final left = _evaluateValue(state, parts[0], self: self);
+        final right = _evaluateValue(state, parts[1], self: self);
         return left < right;
       }
     }
@@ -53,8 +55,8 @@ class ExpressionEvaluator {
     if (expr.contains('==')) {
       final parts = expr.split('==').map((e) => e.trim()).toList();
       if (parts.length == 2) {
-        final left = _evaluateValue(state, parts[0]);
-        final right = _evaluateValue(state, parts[1]);
+        final left = _evaluateValue(state, parts[0], self: self);
+        final right = _evaluateValue(state, parts[1], self: self);
         return left == right;
       }
     }
@@ -62,16 +64,16 @@ class ExpressionEvaluator {
     if (expr.contains('!=')) {
       final parts = expr.split('!=').map((e) => e.trim()).toList();
       if (parts.length == 2) {
-        final left = _evaluateValue(state, parts[0]);
-        final right = _evaluateValue(state, parts[1]);
+        final left = _evaluateValue(state, parts[0], self: self);
+        final right = _evaluateValue(state, parts[1], self: self);
         return left != right;
       }
     }
 
-    return _evaluateValue(state, expr) > 0;
+    return _evaluateValue(state, expr, self: self) > 0;
   }
 
-  static int _evaluateValue(GameState state, String expr) {
+  static int _evaluateValue(GameState state, String expr, {CardInstance? self}) {
     switch (expr) {
       case 'hand.count':
         return state.hand.count;
@@ -97,6 +99,11 @@ class ExpressionEvaluator {
       default:
         if (int.tryParse(expr) != null) {
           return int.parse(expr);
+        }
+        // self.counter('key') 形式: トリガー発生元カードのメタデータからカウンターを取得する
+        if (self != null && expr.startsWith("self.counter('") && expr.endsWith("')")) {
+          final key = expr.substring("self.counter('".length, expr.length - 2);
+          return (self.metadata[key] as int?) ?? 0;
         }
         if (expr.startsWith('count(')) {
           return _evaluateCountExpression(state, expr);

--- a/lib/domain/services/field_rule.dart
+++ b/lib/domain/services/field_rule.dart
@@ -53,10 +53,20 @@ class FieldRule {
         state.spellsCastThisTurn++;
         logs.add('Cast spell: ${card.card.name}');
         state.grave.add(card);
-        
+
         for (final ability in card.card.abilities) {
           if (ability.when == TriggerWhen.onPlay) {
             TriggerService.enqueueAbility(state, card, ability);
+          }
+        }
+
+        // domain カードの on_spell_played アビリティを通知
+        if (state.hasDomain) {
+          final domain = state.currentDomain!;
+          for (final ability in domain.card.abilities) {
+            if (ability.when == TriggerWhen.onSpellPlayed) {
+              TriggerService.enqueueAbility(state, domain, ability);
+            }
           }
         }
         break;

--- a/lib/domain/services/trigger_service.dart
+++ b/lib/domain/services/trigger_service.dart
@@ -87,7 +87,8 @@ class TriggerService {
       // すべての事前条件をチェック
       bool allPreConditionsMet = true;
       for (final condition in trigger.ability.pre!) {
-        final conditionResult = ExpressionEvaluator.evaluate(state, condition);
+        final conditionResult =
+          ExpressionEvaluator.evaluate(state, condition, self: trigger.source);
         if (!conditionResult) {
           allPreConditionsMet = false;
           break;
@@ -103,7 +104,7 @@ class TriggerService {
     final effects = trigger.ability.effects;
     for (int i = 0; i < effects.length; i++) {
       final effect = effects[i];
-      final result = OperationExecutor.executeOperation(state, effect);
+      final result = OperationExecutor.executeOperation(state, effect, source: trigger.source);
       logs.addAll(result.logs);
 
       if (result.awaitingChoice) {
@@ -148,6 +149,8 @@ class TriggerService {
         return 'activated';
       case TriggerWhen.onDiscard:
         return 'on_discard';
+      case TriggerWhen.onSpellPlayed:
+        return 'on_spell_played';
     }
   }
 }

--- a/lib/presentation/components/card_component.dart
+++ b/lib/presentation/components/card_component.dart
@@ -179,6 +179,30 @@ class CardComponent extends PositionComponent with TapCallbacks, HasGameRef<TCGG
       typePainter.paint(canvas, material.Offset(4, size.y - 13));
     }
 
+    // カウンター表示（metadata に 1 以上の整数値があれば "・N" を描画）
+    final counters = card.metadata.entries
+        .where((e) => e.value is int && (e.value as int) > 0)
+        .toList();
+    if (counters.isNotEmpty) {
+      final totalCount = counters.fold<int>(0, (sum, e) => sum + (e.value as int));
+      final counterPainter = material.TextPainter(
+        text: material.TextSpan(
+          text: '・$totalCount',
+          style: const material.TextStyle(
+            color: material.Color(0xFFFBBF24),
+            fontSize: 9,
+            fontWeight: material.FontWeight.bold,
+            shadows: [
+              material.Shadow(color: material.Colors.black, blurRadius: 2),
+            ],
+          ),
+        ),
+        textDirection: material.TextDirection.ltr,
+      );
+      counterPainter.layout(maxWidth: size.x - 8);
+      counterPainter.paint(canvas, material.Offset(4, size.y - 25));
+    }
+
     // 選択中ゴールドボーダー
     if (_isSelected) {
       canvas.drawRRect(

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -86,16 +86,15 @@ class _GameScreenState extends State<GameScreen> {
             },
           ),
           // カード詳細パネル（選択時にスライドイン）
-          ValueListenableBuilder<CardSelectionState?>(
-            valueListenable: _game.gameState.selectedCard,
-            builder: (context, selection, _) {
-              return Positioned(
-                left: 0,
-                right: 0,
-                bottom: 0,
-                child: AnimatedSlide(
-                  offset:
-                      selection != null ? Offset.zero : const Offset(0, 1),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: ValueListenableBuilder<CardSelectionState?>(
+              valueListenable: _game.gameState.selectedCard,
+              builder: (context, selection, _) {
+                return AnimatedSlide(
+                  offset: selection != null ? Offset.zero : const Offset(0, 1),
                   duration: const Duration(milliseconds: 220),
                   curve: Curves.easeOutCubic,
                   child: AnimatedOpacity(
@@ -105,14 +104,13 @@ class _GameScreenState extends State<GameScreen> {
                         ? CardDetailPanel(
                             selection: selection,
                             onConfirm: _handleConfirm,
-                            onDismiss: () =>
-                                _game.gameState.selectCard(null),
+                            onDismiss: () => _game.gameState.selectCard(null),
                           )
                         : const SizedBox.shrink(),
                   ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ],
       ),

--- a/lib/ui/widgets/card_detail_dialog.dart
+++ b/lib/ui/widgets/card_detail_dialog.dart
@@ -222,6 +222,8 @@ class CardDetailDialog extends StatelessWidget {
         return '起動型';
       case TriggerWhen.onDiscard:
         return '捨て札時';
+      case TriggerWhen.onSpellPlayed:
+        return 'spell発動時';
     }
   }
 

--- a/lib/ui/widgets/card_detail_panel.dart
+++ b/lib/ui/widgets/card_detail_panel.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: deprecated_member_use
 import 'package:flutter/material.dart';
 import '../../domain/models/card_data.dart';
+import '../../domain/models/card_instance.dart';
 import '../../domain/models/card_selection_state.dart';
 import '../theme/game_theme.dart';
 
@@ -62,7 +63,7 @@ class CardDetailPanel extends StatelessWidget {
                 children: [
                   _CardArtwork(card: selection.card.card),
                   const SizedBox(width: 16),
-                  Expanded(child: _CardInfo(card: selection.card.card)),
+                  Expanded(child: _CardInfo(instance: selection.card)),
                   const SizedBox(width: 12),
                   _ActionButtons(
                     canAct: _canAct,
@@ -149,8 +150,10 @@ class _CardArtwork extends StatelessWidget {
 }
 
 class _CardInfo extends StatelessWidget {
-  final CardData card;
-  const _CardInfo({required this.card});
+  final CardInstance instance;
+  const _CardInfo({required this.instance});
+
+  CardData get card => instance.card;
 
   @override
   Widget build(BuildContext context) {
@@ -235,12 +238,46 @@ class _CardInfo extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ],
+        ..._buildCounterChips(instance.metadata),
         if (card.abilities.isNotEmpty) ...[
           const SizedBox(height: 6),
           ..._buildAbilityTexts(card),
         ],
       ],
     );
+  }
+
+  List<Widget> _buildCounterChips(Map<String, dynamic> metadata) {
+    final counters = metadata.entries
+        .where((e) => e.value is int && (e.value as int) > 0)
+        .toList();
+    if (counters.isEmpty) return [];
+
+    return [
+      const SizedBox(height: 6),
+      Wrap(
+        spacing: 6,
+        runSpacing: 4,
+        children: counters.map((e) {
+          return Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFBBF24).withOpacity(0.15),
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: const Color(0xFFFBBF24).withOpacity(0.5)),
+            ),
+            child: Text(
+              'カウンター×${e.value}',
+              style: const TextStyle(
+                color: Color(0xFFFBBF24),
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    ];
   }
 
   List<Widget> _buildAbilityTexts(CardData card) {

--- a/lib/ui/widgets/card_detail_panel.dart
+++ b/lib/ui/widgets/card_detail_panel.dart
@@ -283,6 +283,8 @@ class _CardInfo extends StatelessWidget {
         return '起動効果';
       case TriggerWhen.onDiscard:
         return '廃棄時';
+      case TriggerWhen.onSpellPlayed:
+        return 'spell発動時';
     }
   }
 }

--- a/lib/ui/widgets/card_detail_panel.dart
+++ b/lib/ui/widgets/card_detail_panel.dart
@@ -39,8 +39,8 @@ class CardDetailPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-        color: Colors.transparent,
-        child: Container(
+      color: Colors.transparent,
+      child: Container(
           decoration: BoxDecoration(
             color: const Color(0xF0161B22),
             border: const Border(

--- a/test/data/card_repository_test.dart
+++ b/test/data/card_repository_test.dart
@@ -231,5 +231,26 @@ void main() {
       // Assert
       expect(card!.abilities.first.oncePerTurn, isTrue);
     });
+
+    test('when: on_spell_played は TriggerWhen.onSpellPlayed にパースされる', () {
+      const String cardYaml = '''
+      id: 'dmn_test'
+      name: '水力発電所テスト'
+      type: 'domain'
+      version: 1
+      abilities:
+        - when: 'on_spell_played'
+          once_per_turn: false
+          effect:
+            - op: 'add_counter'
+              key: spell_count
+              amount: 1
+      ''';
+
+      final card = CardRepository.parseCard(cardYaml);
+
+      expect(card!.abilities.first.when, TriggerWhen.onSpellPlayed);
+      expect(card.abilities.first.oncePerTurn, isFalse);
+    });
   });
 }

--- a/test/domain/commands/operation_executor_test.dart
+++ b/test/domain/commands/operation_executor_test.dart
@@ -495,4 +495,70 @@ void main() {
       expect(result.awaitingChoice, isTrue);
     });
   });
+
+  // ----------------------------------------------------------------
+  group('op: add_counter', () {
+    test('source のメタデータにカウンターを追加する', () {
+      final domain = _makeCard('d1', CardType.domain);
+
+      OperationExecutor.executeOperation(
+        state,
+        _op('add_counter', {'key': 'spell_count', 'amount': 1}),
+        source: domain,
+      );
+
+      expect(domain.metadata['spell_count'], 1);
+    });
+
+    test('2回呼ぶとカウンターが累積される', () {
+      final domain = _makeCard('d1', CardType.domain);
+
+      OperationExecutor.executeOperation(
+        state,
+        _op('add_counter', {'key': 'spell_count', 'amount': 1}),
+        source: domain,
+      );
+      OperationExecutor.executeOperation(
+        state,
+        _op('add_counter', {'key': 'spell_count', 'amount': 1}),
+        source: domain,
+      );
+
+      expect(domain.metadata['spell_count'], 2);
+    });
+
+    test('source が null のとき failure を返す', () {
+      final result = OperationExecutor.executeOperation(
+        state,
+        _op('add_counter', {'key': 'spell_count', 'amount': 1}),
+      );
+
+      expect(result.success, isFalse);
+    });
+  });
+
+  // ----------------------------------------------------------------
+  group('op: remove_counter', () {
+    test('source のメタデータのカウンターを 0 にリセットする', () {
+      final domain = _makeCard('d1', CardType.domain);
+      domain.metadata['spell_count'] = 4;
+
+      OperationExecutor.executeOperation(
+        state,
+        _op('remove_counter', {'key': 'spell_count'}),
+        source: domain,
+      );
+
+      expect(domain.metadata['spell_count'], 0);
+    });
+
+    test('source が null のとき failure を返す', () {
+      final result = OperationExecutor.executeOperation(
+        state,
+        _op('remove_counter', {'key': 'spell_count'}),
+      );
+
+      expect(result.success, isFalse);
+    });
+  });
 }

--- a/test/domain/services/dmn_suiryoku_integration_test.dart
+++ b/test/domain/services/dmn_suiryoku_integration_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:solitcg/core/game_state.dart';
+import 'package:solitcg/domain/models/card_data.dart';
+import 'package:solitcg/domain/models/card_instance.dart';
+import 'package:solitcg/domain/services/field_rule.dart';
+import 'package:solitcg/domain/services/trigger_service.dart';
+
+/// 水力発電所カードの統合テスト。
+/// spell を順次プレイし、4枚目でカードを1枚引くことを検証する。
+
+CardInstance _makeSpell(String id) {
+  return CardInstance(
+    card: CardData(id: id, name: id, type: CardType.spell),
+    instanceId: id,
+  );
+}
+
+CardInstance _makeSuiryoku() {
+  final addCounter = Ability(
+    when: TriggerWhen.onSpellPlayed,
+    effects: [const EffectStep(op: 'add_counter', params: {'key': 'spell_count', 'amount': 1})],
+    oncePerTurn: false,
+  );
+  final drawOnFour = Ability(
+    when: TriggerWhen.onSpellPlayed,
+    pre: ["self.counter('spell_count') >= 4"],
+    effects: [
+      const EffectStep(op: 'remove_counter', params: {'key': 'spell_count'}),
+      const EffectStep(op: 'draw', params: {'count': 1}),
+    ],
+    oncePerTurn: false,
+  );
+  return CardInstance(
+    card: CardData(
+      id: 'dmn_suiryoku_001',
+      name: '水力発電所',
+      type: CardType.domain,
+      abilities: [addCounter, drawOnFour],
+    ),
+    instanceId: 'suiryoku_inst',
+  );
+}
+
+void main() {
+  late GameState state;
+  void noopUpdate() {}
+
+  setUp(() {
+    state = GameState();
+  });
+
+  group('水力発電所 — 統合テスト', () {
+    test('spell を4枚プレイするとカードを1枚引く', () async {
+      final domain = _makeSuiryoku();
+      state.domain.add(domain);
+      state.deck.add(_makeSpell('deck_card'));
+
+      for (int i = 0; i < 4; i++) {
+        FieldRule.playCard(state, _makeSpell('s$i'));
+        await TriggerService.resolveAll(state, noopUpdate);
+      }
+
+      expect(state.hand.count, 1);
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
+    test('spell を4枚プレイするとカウンターが 0 にリセットされる', () async {
+      final domain = _makeSuiryoku();
+      state.domain.add(domain);
+      state.deck.add(_makeSpell('deck_card'));
+
+      for (int i = 0; i < 4; i++) {
+        FieldRule.playCard(state, _makeSpell('s$i'));
+        await TriggerService.resolveAll(state, noopUpdate);
+      }
+
+      expect(domain.metadata['spell_count'], 0);
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
+    test('spell を3枚プレイしても手札は増えない', () async {
+      final domain = _makeSuiryoku();
+      state.domain.add(domain);
+
+      for (int i = 0; i < 3; i++) {
+        FieldRule.playCard(state, _makeSpell('s$i'));
+        await TriggerService.resolveAll(state, noopUpdate);
+      }
+
+      expect(state.hand.count, 0);
+    }, timeout: const Timeout(Duration(seconds: 25)));
+
+    test('spell を3枚プレイするとカウンターは 3 になる', () async {
+      final domain = _makeSuiryoku();
+      state.domain.add(domain);
+
+      for (int i = 0; i < 3; i++) {
+        FieldRule.playCard(state, _makeSpell('s$i'));
+        await TriggerService.resolveAll(state, noopUpdate);
+      }
+
+      expect(domain.metadata['spell_count'], 3);
+    }, timeout: const Timeout(Duration(seconds: 25)));
+  });
+}

--- a/test/domain/services/expression_evaluator_test.dart
+++ b/test/domain/services/expression_evaluator_test.dart
@@ -153,4 +153,48 @@ void main() {
       expect(ExpressionEvaluator.evaluate(state, ""), isFalse);
     });
   });
+
+  group('ExpressionEvaluator - self.counter() 参照', () {
+    test("self.counter('spell_count') >= 4 はメタデータが4のとき true", () {
+      final self = CardInstance(
+        card: CardData(id: 'd1', name: 'd1', type: CardType.domain),
+        instanceId: 'd1',
+        metadata: {'spell_count': 4},
+      );
+      expect(
+        ExpressionEvaluator.evaluate(state, "self.counter('spell_count') >= 4", self: self),
+        isTrue,
+      );
+    });
+
+    test("self.counter('spell_count') >= 4 はメタデータが3のとき false", () {
+      final self = CardInstance(
+        card: CardData(id: 'd1', name: 'd1', type: CardType.domain),
+        instanceId: 'd1',
+        metadata: {'spell_count': 3},
+      );
+      expect(
+        ExpressionEvaluator.evaluate(state, "self.counter('spell_count') >= 4", self: self),
+        isFalse,
+      );
+    });
+
+    test("self.counter('spell_count') はメタデータ未設定のとき 0 を返す", () {
+      final self = CardInstance(
+        card: CardData(id: 'd1', name: 'd1', type: CardType.domain),
+        instanceId: 'd1',
+      );
+      expect(
+        ExpressionEvaluator.evaluate(state, "self.counter('spell_count') >= 1", self: self),
+        isFalse,
+      );
+    });
+
+    test("self が null のとき self.counter 式は false を返す", () {
+      expect(
+        ExpressionEvaluator.evaluate(state, "self.counter('spell_count') >= 1"),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/domain/services/field_rule_test.dart
+++ b/test/domain/services/field_rule_test.dart
@@ -158,6 +158,53 @@ void main() {
   });
 
   // ----------------------------------------------------------------
+  group('FieldRule.playCard — on_spell_played domain 通知', () {
+    test('spell をプレイすると domain の onSpellPlayed アビリティがキューに積まれる', () {
+      final onSpellPlayedAbility = _makeAbility(TriggerWhen.onSpellPlayed);
+      final domain = _makeCard('d1', CardType.domain, abilities: [onSpellPlayedAbility]);
+      state.domain.add(domain);
+
+      final spell = _makeCard('s1', CardType.spell);
+      FieldRule.playCard(state, spell);
+
+      expect(state.triggerQueue.length, 1);
+      expect(state.triggerQueue.first.ability.when, TriggerWhen.onSpellPlayed);
+    });
+
+    test('domain がないとき spell をプレイしても onSpellPlayed はキューに積まれない', () {
+      final spell = _makeCard('s1', CardType.spell);
+      FieldRule.playCard(state, spell);
+
+      expect(state.triggerQueue.length, 0);
+    });
+
+    test('arcane をプレイしても domain の onSpellPlayed が通知される', () {
+      final onSpellPlayedAbility = _makeAbility(TriggerWhen.onSpellPlayed);
+      final domain = _makeCard('d1', CardType.domain, abilities: [onSpellPlayedAbility]);
+      state.domain.add(domain);
+
+      final arcane = _makeCard('a1', CardType.arcane);
+      FieldRule.playCard(state, arcane);
+
+      expect(state.triggerQueue.length, 1);
+      expect(state.triggerQueue.first.ability.when, TriggerWhen.onSpellPlayed);
+    });
+
+    test('spell の on_play と domain の onSpellPlayed が両方キューに積まれる', () {
+      final onPlayAbility = _makeAbility(TriggerWhen.onPlay);
+      final spell = _makeCard('s1', CardType.spell, abilities: [onPlayAbility]);
+
+      final onSpellPlayedAbility = _makeAbility(TriggerWhen.onSpellPlayed);
+      final domain = _makeCard('d1', CardType.domain, abilities: [onSpellPlayedAbility]);
+      state.domain.add(domain);
+
+      FieldRule.playCard(state, spell);
+
+      expect(state.triggerQueue.length, 2);
+    });
+  });
+
+  // ----------------------------------------------------------------
   group('FieldRule.playCardFromHand — エラーケース', () {
     test('無効なインデックス（負数）は failure を返す', () {
       final result = FieldRule.playCardFromHand(state, -1);


### PR DESCRIPTION
## Summary

- **新カード追加**: 水力発電所 (`dmn_suiryoku_001`) — spell が発動されるたびにカウンターを1つのせ、4つになったら全て取り除きカードを1枚引く domain カード
- **エンジン拡張**: 汎用 per-card カウンターシステムと `on_spell_played` トリガーを実装
- **UI対応**: カード上に `・N`、詳細パネルに `カウンター×N` バッジを表示

## 変更ファイル（エンジン）

- `lib/domain/models/card_data.dart` — `TriggerWhen.onSpellPlayed` を追加
- `lib/data/repositories/card_repository.dart` — `on_spell_played` YAML パースを追加
- `lib/domain/commands/operation_executor.dart` — `add_counter` / `remove_counter` op を追加、`source` パラメータ追加
- `lib/domain/services/expression_evaluator.dart` — `self.counter('key')` 式と `self` パラメータを追加
- `lib/domain/services/trigger_service.dart` — `onSpellPlayed` 対応、`trigger.source` を effect 実行時に伝播
- `lib/domain/services/field_rule.dart` — spell/arcane プレイ後に domain の `onSpellPlayed` を通知

## 変更ファイル（UI）

- `lib/ui/widgets/card_detail_dialog.dart` — `onSpellPlayed` switch ケースを追加
- `lib/ui/widgets/card_detail_panel.dart` — `CardInstance` ベースに変更、カウンターバッジ表示
- `lib/presentation/components/card_component.dart` — カード上に `・N` カウンター描画

## テスト計画

- [x] `test/data/card_repository_test.dart` — `on_spell_played` パース
- [x] `test/domain/services/expression_evaluator_test.dart` — `self.counter()` 式評価
- [x] `test/domain/commands/operation_executor_test.dart` — `add_counter` / `remove_counter` op
- [x] `test/domain/services/field_rule_test.dart` — `onSpellPlayed` domain 通知
- [x] `test/domain/services/dmn_suiryoku_integration_test.dart` — spell 4枚で draw、3枚では変化なし（統合テスト）
- [x] 全120テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)