### PR TITLE
feat: 建設計画カードを追加

### DIFF
--- a/assets/cards/index.yaml
+++ b/assets/cards/index.yaml
@@ -18,3 +18,4 @@ cards:
   - mon_crystal_looters_001.yaml
   - spl_mining_gem.yaml
   - dmn_suiryoku_001.yaml
+  - spl_construction_plan_001.yaml

--- a/assets/cards/spl_construction_plan_001.yaml
+++ b/assets/cards/spl_construction_plan_001.yaml
@@ -1,0 +1,17 @@
+id: spl_construction_plan_001
+name: 建設計画
+type: spell
+tags: []
+text: デッキからdomainカードをランダムに1枚手札に加える。
+version: 1
+
+abilities:
+  - when: on_play
+    effect:
+      - op: search
+        from: deck
+        to: hand
+        filter:
+          type: domain
+        max: 1
+        random: true


### PR DESCRIPTION
## Summary
- `assets/cards/spl_construction_plan_001.yaml` を新規追加
- デッキからdomainカードを1枚ランダムに手札に加えるspellカード
- `assets/cards/index.yaml` にエントリを追加

## Test plan
- [ ] `flutter test` が全件パスすること
- [ ] ゲーム上で建設計画をプレイし、デッキにdomainカードがある場合に手札に加わること
- [ ] デッキにdomainカードがない場合に何も起きないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)