### PR TITLE
Fix Crystal Looters summon condition and effect target

### DIFF
--- a/assets/cards/mon_crystal_looters_001.yaml
+++ b/assets/cards/mon_crystal_looters_001.yaml
@@ -2,8 +2,8 @@ id: mon_crystal_looters_001
 name: クリスタル盗掘団
 type: monster
 tags: [human, thief]
-text: "起動：自分の場のアーティファクト1枚を破壊して発動できる。カードを1枚引く。この能力は1ターンに何度でも使用できる。"
-version: 1
+text: "自分の場にアーティファクトが存在する場合のみ召喚できる。起動：自分の場のアーティファクト1枚を選択して破壊し、カードを1枚引く。この能力は1ターンに何度でも使用できる。"
+version: 2
 
 # monsterタイプのためHPは必須。atk/defは任意ですが、標準的な値を設定しています。
 stats:
@@ -12,6 +12,13 @@ stats:
   hp: 1200
 
 abilities:
+  # 召喚条件：自分の場にアーティファクトが1枚以上存在する場合のみ召喚可能
+  - when: onPlay
+    pre:
+      - "count(type:'artifact', zone:'board:self') >= 1"
+    effect: []
+
+  # 起動効果：自分の場のアーティファクトを選択して破壊し、カードを1枚引く
   - when: activated
     # ターン制限なしの設定（デフォルトはtrueのため明示的にfalseを指定）
     once_per_turn: false
@@ -19,7 +26,7 @@ abilities:
     pre:
       - "count(type:'artifact', zone:'board:self') >= 1"
     effect:
-      # 1. 自分の場のアーティファクトを選択して破壊（コスト・消費処理）
+      # 1. 自分の場のアーティファクトを選択して破壊
       - { op: destroy, target: "choose:self:artifact", count: 1 }
       # 2. カードを1枚引く
       - { op: draw, count: 1 }

--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -3,6 +3,12 @@
 重要な設計・アーキテクチャ判断の時系列記録。
 詳細な根拠は各 ADR（`docs/adr/`）を参照。
 
+## 2026-04-10 - [バグ修正+仕様変更] クリスタル盗掘団の召喚条件・効果ターゲット修正
+
+- **判断内容**: 3点を修正。①`field_rule.dart` の `playCardFromHand` で `activated` abilityのpre条件をカードプレイ時にも適用していたバグを修正（`onPlay` のみチェック対象に変更）。②`operation_executor.dart` の `_executeDestroy` で `target: "choose:self:artifact"` 形式の文字列を未パースだったバグを修正（コロン区切りでパースし `selection='choose'`・filterを抽出）。③カードYAMLに `onPlay` abilityを追加し、「場にArtifactがある時のみ召喚可能」を仕様として明示。
+- **理由**: バグ①によりArtifactなしでカードを出せなかった。バグ②によりArtifact以外の一番左のカードが破壊されていた。仕様変更はユーザーの意図するゲームデザインへの修正。
+- **影響範囲**: `assets/cards/mon_crystal_looters_001.yaml`、`lib/domain/services/field_rule.dart`、`lib/domain/commands/operation_executor.dart`
+
 ## 2026-04-09 - [設計変更] spellsCastThisTurn カウンター廃止・魔法省カード追加
 
 - **判断内容**: ターン中のスペル詠唱回数カウンター（`spellsCastThisTurn`）を GameState・FieldRule・ExpressionEvaluator・HUD・tcg_game.dart から完全削除。依存していた `spl_x07（閃考の儀）` を削除し、代替として `dmn_mahou_001（魔法省）` ドメインカードを追加。魔法省はスペルをプレイされるたびカウンターを累積し、8個で勝利する。

--- a/lib/domain/commands/operation_executor.dart
+++ b/lib/domain/commands/operation_executor.dart
@@ -194,11 +194,24 @@ class OperationExecutor {
   }
 
   static GameResult _executeDestroy(GameState state, Map<String, dynamic> params) {
-    final target = params['target'] as String? ?? 'board';
-    final filter = _parseFilter(params['filter']);
-    final selection = params['selection'] as String?;
+    final targetRaw = params['target'] as String? ?? 'board';
+    var filter = _parseFilter(params['filter']);
+    var selection = params['selection'] as String?;
     final count = params['count'] as int? ?? 1;
     final logs = <String>[];
+
+    // "choose:self:artifact" 形式のtargetをパース
+    String target = targetRaw;
+    if (targetRaw.contains(':')) {
+      final parts = targetRaw.split(':');
+      if (parts[0] == 'choose') {
+        selection = 'choose';
+        if (parts.length >= 3 && parts[2].isNotEmpty) {
+          filter = {'type': parts[2]};
+        }
+        target = 'board';
+      }
+    }
 
     if (target == 'domain' && state.hasDomain) {
       final domainCard = state.domain.removeAt(0)!;

--- a/lib/domain/services/field_rule.dart
+++ b/lib/domain/services/field_rule.dart
@@ -110,7 +110,7 @@ class FieldRule {
 
     // Check preconditions for onPlay abilities
     for (final ability in card.card.abilities) {
-      if (ability.when == TriggerWhen.onPlay || ability.when == TriggerWhen.activated) {
+      if (ability.when == TriggerWhen.onPlay) {
         if (ability.pre != null) {
           for (final condition in ability.pre!) {
             if (!ExpressionEvaluator.evaluate(state, condition)) {


### PR DESCRIPTION
## Changes

### Card Definition (`mon_crystal_looters_001.yaml`)
- Added summon condition: card can only be summoned if an Artifact exists on own field
- Added `onPlay` ability to enforce the summon condition
- Updated ability text and bumped version to 2
- Clarified effect target parsing in comments

### Bug Fixes

#### `field_rule.dart`
- Fixed `playCardFromHand` to only check `onPlay` ability preconditions during card play
- Removed incorrect `activated` ability precondition check (was preventing card play without artifacts)

#### `operation_executor.dart`
- Added parsing for `target: "choose:self:artifact"` format in `_executeDestroy`
- Extracts `selection='choose'` and filter from colon-separated target string
- Fixes bug where wrong cards were being destroyed (now correctly targets artifacts)

### Documentation
- Added audit log entry documenting the bug fixes and design decisions

## Impact
Resolves issues where Crystal Looters card could be played without artifacts and wrong cards were being destroyed.