### PR TITLE
feat: Add read-only sample deck (魔法省)

### DIFF
--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -3,6 +3,12 @@
 重要な設計・アーキテクチャ判断の時系列記録。
 詳細な根拠は各 ADR（`docs/adr/`）を参照。
 
+## 2026-04-10 - [機能追加] サンプルデッキ機能の追加
+
+- **判断内容**: `Deck` モデルに `isReadOnly` フィールドを追加し、プレイヤーが編集・削除できないサンプルデッキ「サンプルデッキ＿魔法省」を実装。デッキは `DeckRepository.sampleDeckMahou` として定義し、`DeckCollectionNotifier.loadDecks()` で毎回先頭に注入する。JSONには永続化しない。
+- **理由**: ゲーム開始直後からプレイ可能なデッキを提供することで、ユーザーがデッキ構築なしにゲームを体験できるようにする。
+- **影響範囲**: `lib/domain/models/deck.dart`（`isReadOnly` フィールド追加）、`lib/data/repositories/deck_repository.dart`（サンプルデッキ定義・`saveDecks` フィルター追加）、`lib/providers/deck_provider.dart`（注入・ガード追加）、`lib/ui/screens/deck_selector_screen.dart`（サンプルチップ表示・ボタン非表示）、`lib/ui/screens/deck_builder_screen.dart`（編集操作の無効化）
+
 ## 2026-04-09 - [設計変更] spellsCastThisTurn カウンター廃止・魔法省カード追加
 
 - **判断内容**: ターン中のスペル詠唱回数カウンター（`spellsCastThisTurn`）を GameState・FieldRule・ExpressionEvaluator・HUD・tcg_game.dart から完全削除。依存していた `spl_x07（閃考の儀）` を削除し、代替として `dmn_mahou_001（魔法省）` ドメインカードを追加。魔法省はスペルをプレイされるたびカウンターを累積し、8個で勝利する。

--- a/lib/data/repositories/deck_repository.dart
+++ b/lib/data/repositories/deck_repository.dart
@@ -13,10 +13,66 @@ class DeckRepository {
   static const String deckFileName = 'decks.json';
   static const String localStorageKey = 'solitcg_decks';
   
+  /// サンプルデッキ＿魔法省（読み取り専用）
+  static Deck get sampleDeckMahou {
+    const cardIds = [
+      'activated_artifact',
+      'activated_artifact',
+      'activated_artifact',
+      'activated_artifact',
+      'atf_crystal_001',
+      'atf_crystal_001',
+      'atf_crystal_001',
+      'atf_crystal_001',
+      'dmn_mahou_001',
+      'dmn_mahou_001',
+      'dmn_mahou_001',
+      'dmn_mahou_001',
+      'mon_crystal_looters_001',
+      'mon_crystal_looters_001',
+      'mon_crystal_looters_001',
+      'mon_crystal_looters_001',
+      'mon_akuma_001',
+      'mon_akuma_001',
+      'mon_akuma_001',
+      'mon_akuma_001',
+      'mon_robot_001',
+      'mon_robot_001',
+      'mon_robot_001',
+      'mon_robot_001',
+      'simple_draw_001',
+      'simple_draw_001',
+      'simple_draw_001',
+      'simple_draw_001',
+      'spl_construction_plan_001',
+      'spl_construction_plan_001',
+      'spl_construction_plan_001',
+      'spl_construction_plan_001',
+      'spl_mining_gem_001',
+      'spl_mining_gem_001',
+      'spl_mining_gem_001',
+      'spl_mining_gem_001',
+      'spl_typhoon',
+      'spl_typhoon',
+      'spl_typhoon',
+      'spl_typhoon',
+    ];
+    return Deck(
+      id: 'sample_mahou_sho',
+      name: 'サンプルデッキ＿魔法省',
+      type: DeckType.main,
+      cardIds: List<String>.from(cardIds),
+      isReadOnly: true,
+    );
+  }
+
   /// デッキコレクションを保存
   static Future<bool> saveDecks(DeckCollection collection) async {
     try {
-      final jsonData = jsonEncode(collection.toJson());
+      // 読み取り専用デッキは永続化しない
+      final saveable = DeckCollection()
+        ..decks = collection.decks.where((d) => !d.isReadOnly).toList();
+      final jsonData = jsonEncode(saveable.toJson());
       
       if (kIsWeb) {
         // Webの場合はローカルストレージに保存

--- a/lib/domain/models/deck.dart
+++ b/lib/domain/models/deck.dart
@@ -10,12 +10,14 @@ class Deck {
   String name;                   // デッキ名
   DeckType type;                 // デッキタイプ
   List<String> cardIds = [];     // カードIDのリスト
-  
+  final bool isReadOnly;         // 読み取り専用フラグ（サンプルデッキ等）
+
   Deck({
     required this.id,
     required this.name,
     required this.type,
     List<String>? cardIds,
+    this.isReadOnly = false,
   }) : cardIds = cardIds ?? [];
   
   /// デッキ内のカード枚数

--- a/lib/providers/deck_provider.dart
+++ b/lib/providers/deck_provider.dart
@@ -55,7 +55,9 @@ class DeckCollectionNotifier extends StateNotifier<DeckCollection> {
   
   // デッキコレクションの読み込み
   Future<void> loadDecks() async {
-    state = await DeckRepository.loadDecks();
+    final loaded = await DeckRepository.loadDecks();
+    final sample = DeckRepository.sampleDeckMahou;
+    state = DeckCollection()..decks = [sample, ...loaded.decks];
   }
   
   // デッキの追加
@@ -67,13 +69,16 @@ class DeckCollectionNotifier extends StateNotifier<DeckCollection> {
   
   // デッキの更新
   void updateDeck(Deck deck) {
+    if (deck.isReadOnly) return;
     final newDecks = state.decks.map((d) => d.id == deck.id ? deck : d).toList();
     state = DeckCollection()..decks = newDecks;
     _saveDecks();
   }
-  
+
   // デッキの削除
   void removeDeck(String deckId) {
+    final target = state.getDeck(deckId);
+    if (target == null || target.isReadOnly) return;
     final newDecks = state.decks.where((d) => d.id != deckId).toList();
     state = DeckCollection()..decks = newDecks;
     _saveDecks();
@@ -81,19 +86,23 @@ class DeckCollectionNotifier extends StateNotifier<DeckCollection> {
   
   // デッキのカードを追加
   void addCardToDeck(String deckId, String cardId) {
+    final target = state.getDeck(deckId);
+    if (target == null || target.isReadOnly) return;
     final newDecks = state.decks.map((deck) {
       if (deck.id == deckId) {
         final newCardIds = [...deck.cardIds, cardId];
-        return Deck(id: deck.id, name: deck.name, type: deck.type, cardIds: newCardIds);
+        return Deck(id: deck.id, name: deck.name, type: deck.type, cardIds: newCardIds, isReadOnly: deck.isReadOnly);
       }
       return deck;
     }).toList();
     state = DeckCollection()..decks = newDecks;
     _saveDecks();
   }
-  
+
   // デッキのカードを削除
   void removeCardFromDeck(String deckId, String cardId) {
+    final target = state.getDeck(deckId);
+    if (target == null || target.isReadOnly) return;
     final newDecks = state.decks.map((deck) {
       if (deck.id == deckId) {
         final newCardIds = [...deck.cardIds];
@@ -102,7 +111,7 @@ class DeckCollectionNotifier extends StateNotifier<DeckCollection> {
         if (index != -1) {
           newCardIds.removeAt(index);
         }
-        return Deck(id: deck.id, name: deck.name, type: deck.type, cardIds: newCardIds);
+        return Deck(id: deck.id, name: deck.name, type: deck.type, cardIds: newCardIds, isReadOnly: deck.isReadOnly);
       }
       return deck;
     }).toList();
@@ -118,7 +127,8 @@ class DeckCollectionNotifier extends StateNotifier<DeckCollection> {
   // デフォルトデッキの作成
   Future<void> createDefaultDecks(List<CardData> allCards) async {
     final defaultCollection = await DeckRepository.createDefaultDecks(allCards);
-    state = defaultCollection;
+    final sample = DeckRepository.sampleDeckMahou;
+    state = DeckCollection()..decks = [sample, ...defaultCollection.decks];
     _saveDecks();
   }
 }

--- a/lib/ui/screens/deck_builder_screen.dart
+++ b/lib/ui/screens/deck_builder_screen.dart
@@ -21,7 +21,7 @@ class DeckBuilderScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text(selectedDeck?.name ?? 'デッキビルダー'),
         actions: [
-          if (selectedDeck != null)
+          if (selectedDeck != null && !selectedDeck.isReadOnly)
             ..._buildAppBarActions(context, ref, selectedDeck),
         ],
       ),
@@ -244,13 +244,14 @@ class _DeckContentView extends ConsumerWidget {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Text('×${entry.value}'),
-                          IconButton(
-                            icon: const Icon(Icons.remove_circle_outline,
-                                color: Colors.red),
-                            onPressed: () => ref
-                                .read(deckCollectionProvider.notifier)
-                                .removeCardFromDeck(deck.id, card.id),
-                          ),
+                          if (!deck.isReadOnly)
+                            IconButton(
+                              icon: const Icon(Icons.remove_circle_outline,
+                                  color: Colors.red),
+                              onPressed: () => ref
+                                  .read(deckCollectionProvider.notifier)
+                                  .removeCardFromDeck(deck.id, card.id),
+                            ),
                         ],
                       ),
                     );
@@ -388,7 +389,7 @@ class _CardCollectionViewState extends ConsumerState<_CardCollectionView> {
                   itemBuilder: (context, index) {
                     final card = filteredCards[index];
                     return InkWell(
-                      onTap: () => _addCardToDeck(card),
+                      onTap: widget.deck.isReadOnly ? null : () => _addCardToDeck(card),
                       onLongPress: () => showDialog(
                           context: context,
                           builder: (context) => CardDetailDialog(card: card)),

--- a/lib/ui/screens/deck_selector_screen.dart
+++ b/lib/ui/screens/deck_selector_screen.dart
@@ -129,15 +129,22 @@ class DeckSelectorScreen extends ConsumerWidget {
           children: [
             const SizedBox(height: 4),
             Text('${deck.cardCount}枚のカード'),
+            if (deck.isReadOnly)
+              const Chip(
+                label: Text('サンプル'),
+                visualDensity: VisualDensity.compact,
+              ),
           ],
         ),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(icon: const Icon(Icons.edit), onPressed: () => _selectDeck(context, ref, deck)),
-            IconButton(icon: const Icon(Icons.delete, color: Colors.red), onPressed: () => _deleteDeck(context, ref, deck)),
-          ],
-        ),
+        trailing: deck.isReadOnly
+            ? null
+            : Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(icon: const Icon(Icons.edit), onPressed: () => _selectDeck(context, ref, deck)),
+                  IconButton(icon: const Icon(Icons.delete, color: Colors.red), onPressed: () => _deleteDeck(context, ref, deck)),
+                ],
+              ),
         onTap: () => _selectDeck(context, ref, deck),
       ),
     );


### PR DESCRIPTION
## Changes

- Added `isReadOnly` field to `Deck` model to support read-only sample decks
- Implemented sample deck "サンプルデッキ＿魔法省" in `DeckRepository.sampleDeckMahou`
- Sample deck is injected at the start of deck collection and persisted in memory only (not in JSON)
- Added guards in `DeckCollectionNotifier` to prevent editing/deletion of read-only decks
- Updated UI to:
  - Show "サンプル" chip badge on read-only decks
  - Hide edit/delete buttons for read-only decks
  - Disable card addition/removal in deck builder for read-only decks
- Updated `DeckRepository.saveDecks()` to exclude read-only decks from persistence
- Updated audit log documenting the design decision

## Rationale

Provides players with a playable deck immediately after game start without requiring deck construction, improving initial user experience.