### PR TITLE
feat: 勝利・敗北時のゲームオーバーオーバーレイ演出を追加

### DIFF
--- a/docs/audit_log.md
+++ b/docs/audit_log.md
@@ -3,6 +3,12 @@
 重要な設計・アーキテクチャ判断の時系列記録。
 詳細な根拠は各 ADR（`docs/adr/`）を参照。
 
+## 2026-04-10 - [機能追加] 勝利・敗北時のゲームオーバーオーバーレイ演出を追加
+
+- **判断内容**: `GameState` に `ValueNotifier<bool?> gameOverNotifier` を追加し、`OperationExecutor` の `_executeWin` / `_executeWinIf` / `_executeLoseIf` で勝敗確定時に通知する。新規ウィジェット `GameOverOverlay` を作成し（勝利=金色スケールイン、敗北=赤フェードイン）、`GameScreen` の Stack 最上位に `ValueListenableBuilder` で組み込んだ。
+- **理由**: 勝敗フラグは既存だったが UI への通知手段がなく、ゲーム終了後も画面に変化がなかった。プレイヤーへのフィードバックとして演出が必要。
+- **影響範囲**: `lib/core/game_state.dart`、`lib/domain/commands/operation_executor.dart`、`lib/ui/widgets/game_over_overlay.dart`（新規）、`lib/ui/screens/game_screen.dart`
+
 ## 2026-04-10 - [バグ修正+仕様変更] クリスタル盗掘団の召喚条件・効果ターゲット修正
 
 - **判断内容**: 3点を修正。①`field_rule.dart` の `playCardFromHand` で `activated` abilityのpre条件をカードプレイ時にも適用していたバグを修正（`onPlay` のみチェック対象に変更）。②`operation_executor.dart` の `_executeDestroy` で `target: "choose:self:artifact"` 形式の文字列を未パースだったバグを修正（コロン区切りでパースし `selection='choose'`・filterを抽出）。③カードYAMLに `onPlay` abilityを追加し、「場にArtifactがある時のみ召喚可能」を仕様として明示。

--- a/lib/core/game_state.dart
+++ b/lib/core/game_state.dart
@@ -33,6 +33,9 @@ class GameState {
   /// 現在選択中のカード状態。Flutter UI の詳細パネル表示に使用する。
   final ValueNotifier<CardSelectionState?> selectedCard = ValueNotifier(null);
 
+  /// ゲーム終了通知。null=ゲーム中、true=勝利、false=敗北
+  final ValueNotifier<bool?> gameOverNotifier = ValueNotifier(null);
+
   /// カードの選択状態を更新する。null を渡すと選択解除。
   void selectCard(CardSelectionState? selection) {
     selectedCard.value = selection;

--- a/lib/domain/commands/operation_executor.dart
+++ b/lib/domain/commands/operation_executor.dart
@@ -267,6 +267,7 @@ class OperationExecutor {
 
   static GameResult _executeWin(GameState state) {
     state.gameWon = true;
+    state.gameOverNotifier.value = true;
     return GameResult.success(logs: ['VICTORY']);
   }
 
@@ -279,6 +280,7 @@ class OperationExecutor {
     final condition = ExpressionEvaluator.evaluate(state, expr);
     if (condition) {
       state.gameWon = true;
+      state.gameOverNotifier.value = true;
       return GameResult.success(logs: ['VICTORY: $expr']);
     }
 
@@ -294,6 +296,7 @@ class OperationExecutor {
     final condition = ExpressionEvaluator.evaluate(state, expr);
     if (condition) {
       state.gameLost = true;
+      state.gameOverNotifier.value = false;
       return GameResult.success(logs: ['DEFEAT: $expr']);
     }
 

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -7,6 +7,7 @@ import '../../domain/models/deck.dart';
 import '../../presentation/game/tcg_game.dart';
 import '../widgets/card_detail_panel.dart';
 import '../widgets/choice_overlay.dart';
+import '../widgets/game_over_overlay.dart';
 
 /// ゲームプレイ画面
 ///
@@ -83,6 +84,14 @@ class _GameScreenState extends State<GameScreen> {
                 request: request,
                 onConfirm: (selected) => _game.resolveChoice(selected),
               );
+            },
+          ),
+          // ゲームオーバーオーバーレイ（勝利・敗北時に表示）
+          ValueListenableBuilder<bool?>(
+            valueListenable: _game.gameState.gameOverNotifier,
+            builder: (context, result, _) {
+              if (result == null) return const SizedBox.shrink();
+              return GameOverOverlay(isWin: result);
             },
           ),
           // カード詳細パネル（選択時にスライドイン）

--- a/lib/ui/widgets/game_over_overlay.dart
+++ b/lib/ui/widgets/game_over_overlay.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import '../theme/game_theme.dart';
+
+/// ゲーム終了時の演出オーバーレイ。
+///
+/// [isWin] が true のとき勝利演出（金色タイトル + スケールイン）、
+/// false のとき敗北演出（赤系タイトル + フェードイン）を表示する。
+class GameOverOverlay extends StatefulWidget {
+  final bool isWin;
+
+  const GameOverOverlay({super.key, required this.isWin});
+
+  @override
+  State<GameOverOverlay> createState() => _GameOverOverlayState();
+}
+
+class _GameOverOverlayState extends State<GameOverOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late final Animation<double> _fade;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+    _fade = CurvedAnimation(parent: _ctrl, curve: Curves.easeIn);
+    _scale = CurvedAnimation(parent: _ctrl, curve: Curves.elasticOut);
+    _ctrl.forward();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _fade,
+      child: Container(
+        color: Colors.black.withOpacity(0.82),
+        child: Center(
+          child: ScaleTransition(
+            scale: widget.isWin ? _scale : _fade,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildTitle(),
+                const SizedBox(height: 16),
+                _buildSubtext(),
+                const SizedBox(height: 48),
+                _buildMenuButton(context),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTitle() {
+    if (widget.isWin) {
+      return ShaderMask(
+        shaderCallback: (bounds) => const LinearGradient(
+          colors: [Color(0xFFFFD700), Color(0xFFFFF176), Color(0xFFFFD700)],
+          stops: [0.0, 0.5, 1.0],
+        ).createShader(bounds),
+        child: const Text(
+          '勝利！',
+          style: TextStyle(
+            fontSize: 72,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+            letterSpacing: 4,
+            shadows: [
+              Shadow(
+                color: Color(0xFFFFD700),
+                blurRadius: 24,
+                offset: Offset(0, 0),
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      return const Text(
+        '敗北...',
+        style: TextStyle(
+          fontSize: 64,
+          fontWeight: FontWeight.bold,
+          color: Color(0xFFEF4444),
+          letterSpacing: 4,
+          shadows: [
+            Shadow(
+              color: Color(0xFF7F1D1D),
+              blurRadius: 20,
+              offset: Offset(0, 4),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  Widget _buildSubtext() {
+    return Text(
+      widget.isWin ? 'コンボを制した！' : 'またの挑戦を待っている',
+      style: TextStyle(
+        fontSize: 18,
+        color: widget.isWin
+            ? const Color(0xFFFEF9C3)
+            : const Color(0xFF94A3B8),
+        letterSpacing: 1.5,
+      ),
+    );
+  }
+
+  Widget _buildMenuButton(BuildContext context) {
+    return OutlinedButton(
+      onPressed: () => Navigator.of(context).pop(),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: widget.isWin
+            ? GameTheme.selectionGlow
+            : const Color(0xFF94A3B8),
+        side: BorderSide(
+          color: widget.isWin
+              ? GameTheme.selectionGlow
+              : const Color(0xFF475569),
+          width: 1.5,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      ),
+      child: const Text(
+        'メニューに戻る',
+        style: TextStyle(fontSize: 16, letterSpacing: 1),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- `GameState` に `gameOverNotifier` (`ValueNotifier<bool?>`) を追加し、勝敗の UI 通知手段を実装
- `OperationExecutor` の `win` / `win_if` / `lose_if` op で確定時に notifier へ通知
- `GameOverOverlay` ウィジェットを新規作成（勝利: 金グラデーション + elasticOut スケールイン、敗北: 赤タイトル + フェードイン）
- `GameScreen` の Stack 最上位に `ValueListenableBuilder` でオーバーレイを組み込み

## Test plan

- [ ] `flutter test test/domain/` が全通過すること（実施済み: exit 0）
- [ ] `win` op を持つカードを使ってゲームを実行し、勝利オーバーレイが表示されること
- [ ] 「メニューに戻る」ボタンでデッキ選択画面に戻れること
- [ ] `lose_if` 条件が成立した場合に敗北オーバーレイが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)