### PR TITLE
Add mobile scroll support & opponent area toggle

### DIFF
--- a/lib/core/game_state.dart
+++ b/lib/core/game_state.dart
@@ -26,7 +26,8 @@ class GameState {
   bool gameLost = false;
 
   final Queue<Trigger> triggerQueue = Queue<Trigger>();
-  final List<String> actionLog = [];
+  final ValueNotifier<List<String>> actionLogNotifier = ValueNotifier([]);
+  List<String> get actionLog => actionLogNotifier.value;
 
   final ValueNotifier<ChoiceRequest?> choiceRequest = ValueNotifier(null);
 
@@ -71,7 +72,12 @@ class GameState {
   int getNextTriggerOrder() => ++_triggerOrder;
 
   void addToLog(String message) {
-    actionLog.add(message);
+    actionLogNotifier.value = [...actionLogNotifier.value, message];
+  }
+
+  void addAllToLog(List<String> messages) {
+    if (messages.isEmpty) return;
+    actionLogNotifier.value = [...actionLogNotifier.value, ...messages];
   }
 
   bool get isGameOver => gameWon || gameLost;

--- a/lib/presentation/components/board_component.dart
+++ b/lib/presentation/components/board_component.dart
@@ -76,22 +76,29 @@ class BoardComponent extends PositionComponent
   // 縦スクロール
   double _viewScrollY = 0.0;
   static const double _totalContentH = 725.0;
-  // 相手エリアの高さ（非表示時にビューをシフトする量）
-  static const double _opponentAreaH = _separatorY; // 360.0
+  // 相手の手札・フィールドゾーン高さ（HUDを除いた部分）
+  static const double _opponentAreaH = _separatorY - _oppHandZoneY; // 330.0
 
   // トリガーキュー（毎フレーム再生成）
   final List<Component> _triggerQueueComponents = [];
 
-  // 相手エリア表示フラグ（外部から setter で制御）
+  // 相手エリア（手札・フィールド）表示フラグ
+  // _opponentAreaOffset: _viewScrollY と独立した固定オフセット
+  // 画面が大きい場合でもクランプに消されず確実にシフトする
   bool _opponentAreaVisible = true;
+  double _opponentAreaOffset = 0.0;
+
   bool get opponentAreaVisible => _opponentAreaVisible;
   set opponentAreaVisible(bool value) {
     if (_opponentAreaVisible == value) return;
     _opponentAreaVisible = value;
-    // 非表示にしたら相手エリア分だけ上にシフト、表示に戻したら元に戻す
-    _viewScrollY += value ? _opponentAreaH : -_opponentAreaH;
+    // HUDは常に表示。手札・フィールド非表示時はその分だけ上へ固定シフト
+    _opponentAreaOffset = value ? 0.0 : -_opponentAreaH;
     _clampViewScrollY();
   }
+
+  // 描画・ヒットテストに使う実効スクロール量
+  double get _effectiveScrollY => _viewScrollY + _opponentAreaOffset;
 
   void _clampViewScrollY() {
     final effectiveH = _opponentAreaVisible
@@ -145,8 +152,8 @@ class BoardComponent extends PositionComponent
   void update(double dt) {
     super.update(dt);
     // ClipComponent の縦位置を毎フレーム同期
-    _boardClipComponent.position = Vector2(_plyBoardX, _plyFieldY + _viewScrollY);
-    _handClipComponent.position = Vector2(10, _plyHandZoneY + _viewScrollY);
+    _boardClipComponent.position = Vector2(_plyBoardX, _plyFieldY + _effectiveScrollY);
+    _handClipComponent.position = Vector2(10, _plyHandZoneY + _effectiveScrollY);
     _updateHand();
     _updateField();
     _updateTriggerQueue();
@@ -173,15 +180,18 @@ class BoardComponent extends PositionComponent
           material.Offset(0, y), material.Offset(size.x, y), gridPaint);
     }
 
-    // ─── 相手エリア ───────────────────────────────────────────
-    if (opponentAreaVisible) {
-      _renderOpponentArea(canvas);
+    // ─── 相手HUD（ライフ等）は常に表示 ─────────────────────────
+    _renderOpponentHud(canvas);
+
+    // ─── 相手の手札・フィールドゾーン（トグルで非表示可） ────
+    if (_opponentAreaVisible) {
+      _renderOpponentHandAndField(canvas);
     }
 
     // ─── セパレーター ─────────────────────────────────────────
     canvas.drawLine(
-      material.Offset(0, _separatorY + _viewScrollY),
-      material.Offset(size.x, _separatorY + _viewScrollY),
+      material.Offset(0, _separatorY + _effectiveScrollY),
+      material.Offset(size.x, _separatorY + _effectiveScrollY),
       material.Paint()
         ..color = GameTheme.zoneBorder.withOpacity(0.6)
         ..strokeWidth = 1.5,
@@ -190,13 +200,13 @@ class BoardComponent extends PositionComponent
     // ─── 自分フィールドゾーン ─────────────────────────────────
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(_plyDomainX, _plyFieldY + _viewScrollY, _domainW, _fieldH),
+      material.Rect.fromLTWH(_plyDomainX, _plyFieldY + _effectiveScrollY, _domainW, _fieldH),
       GameTheme.domainZoneBg,
       'ドメイン',
     );
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(_plyBoardX, _plyFieldY + _viewScrollY, _plyBoardZoneWidth, _fieldH),
+      material.Rect.fromLTWH(_plyBoardX, _plyFieldY + _effectiveScrollY, _plyBoardZoneWidth, _fieldH),
       GameTheme.boardZoneBg,
       'フィールド',
     );
@@ -204,7 +214,7 @@ class BoardComponent extends PositionComponent
     // ─── 自分手札ゾーン ───────────────────────────────────────
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(10, _plyHandZoneY + _viewScrollY, size.x - 20, _plyHandZoneH),
+      material.Rect.fromLTWH(10, _plyHandZoneY + _effectiveScrollY, size.x - 20, _plyHandZoneH),
       GameTheme.handZoneBg,
       '手札',
     );
@@ -217,11 +227,10 @@ class BoardComponent extends PositionComponent
 
   // ─── 相手エリア ───────────────────────────────────────────────
 
-  void _renderOpponentArea(material.Canvas canvas) {
+  /// 相手HUD（ライフ・手札枚数等）は常に表示
+  void _renderOpponentHud(material.Canvas canvas) {
     final state = gameRef.gameState;
-    final s = _viewScrollY;
-
-    // 相手 HUD（ライフ・手札枚数・デッキ枚数・墓地枚数）
+    final s = _viewScrollY; // HUDはユーザースクロールのみ追従（トグルオフセット不要）
     _renderPill(canvas, '♥ ${state.opponentLife}',
         material.Offset(10, _oppHudY + s), GameTheme.hudLifeColor);
     _renderPill(canvas, '🂠 ${state.opponentHandCount}',
@@ -230,6 +239,12 @@ class BoardComponent extends PositionComponent
         material.Offset(180, _oppHudY + s), GameTheme.hudDimColor);
     _renderPill(canvas, '☠ 0',
         material.Offset(235, _oppHudY + s), GameTheme.hudDimColor);
+  }
+
+  /// 相手の手札・フィールドゾーン（トグルで非表示可）
+  void _renderOpponentHandAndField(material.Canvas canvas) {
+    final state = gameRef.gameState;
+    final s = _effectiveScrollY;
 
     // 相手手札ゾーン（裏向きカード）
     _renderZone(
@@ -238,7 +253,7 @@ class BoardComponent extends PositionComponent
       GameTheme.handZoneBg,
       '相手の手札',
     );
-    _renderOpponentHand(canvas, state.opponentHandCount);
+    _renderOpponentHandCards(canvas, state.opponentHandCount);
 
     // 相手フィールド：ボード（左）・ドメイン（右）— 点対称
     _renderZone(
@@ -255,10 +270,10 @@ class BoardComponent extends PositionComponent
     );
   }
 
-  void _renderOpponentHand(material.Canvas canvas, int count) {
+  void _renderOpponentHandCards(material.Canvas canvas, int count) {
     final displayCount = min(count, 7);
     // 右から左に並べる（点対称: 自分の手札は左から右）
-    final cardY = _oppHandZoneY + (_oppHandZoneH - _cardH) / 2 + _viewScrollY;
+    final cardY = _oppHandZoneY + (_oppHandZoneH - _cardH) / 2 + _effectiveScrollY;
     for (int i = 0; i < displayCount; i++) {
       final cardX = size.x - 15 - _cardW - i * 108.0;
       if (cardX < 15) break;
@@ -300,7 +315,7 @@ class BoardComponent extends PositionComponent
 
   void _renderPlayerHud(material.Canvas canvas) {
     final state = gameRef.gameState;
-    final hudY = _plyHudY + _viewScrollY;
+    final hudY = _plyHudY + _effectiveScrollY;
 
     _renderPill(canvas, '♥ ${state.playerLife}',
         material.Offset(10, hudY), GameTheme.hudLifeColor);
@@ -459,7 +474,7 @@ class BoardComponent extends PositionComponent
       // ドメインスロット(plyDomainX, plyFieldY, domainW, fieldH)内に中央配置
       final targetPos = Vector2(
         _plyDomainX + (_domainW - _cardW) / 2,
-        _plyFieldY + (_fieldH - _cardH) / 2 + _viewScrollY,
+        _plyFieldY + (_fieldH - _cardH) / 2 + _effectiveScrollY,
       );
       if (_domainComponentMap.containsKey(domainCard.instanceId)) {
         _domainComponentMap[domainCard.instanceId]!.position = targetPos;
@@ -548,7 +563,7 @@ class BoardComponent extends PositionComponent
 
     final queueTitle = TextComponent(
       text: 'キュー:',
-      position: Vector2(size.x - 180, _separatorY + _viewScrollY + 10),
+      position: Vector2(size.x - 180, _separatorY + _effectiveScrollY + 10),
       textRenderer: TextPaint(
         style: const material.TextStyle(
           color: material.Colors.orange,
@@ -564,7 +579,7 @@ class BoardComponent extends PositionComponent
       final trigger = queue[i];
       final component = TextComponent(
         text: '${i + 1}. ${trigger.source.card.name}',
-        position: Vector2(size.x - 180, _separatorY + _viewScrollY + 26 + i * 18),
+        position: Vector2(size.x - 180, _separatorY + _effectiveScrollY + 26 + i * 18),
         textRenderer: TextPaint(
           style: const material.TextStyle(
             color: material.Colors.white70,
@@ -584,7 +599,7 @@ class BoardComponent extends PositionComponent
     super.onDragStart(event);
     final pos = event.localPosition;
     // スクロール補正後のY座標でヒットテスト
-    final adjustedY = pos.y - _viewScrollY;
+    final adjustedY = pos.y - _effectiveScrollY;
     final boardRect = material.Rect.fromLTWH(
         _plyBoardX, _plyFieldY, _plyBoardZoneWidth, _fieldH);
     final handRect = material.Rect.fromLTWH(
@@ -617,9 +632,26 @@ class BoardComponent extends PositionComponent
 
   // ─── マウスホイール（Flutter Listener から呼び出し） ─────────
 
-  void applyMouseScroll(double dy) {
-    _viewScrollY -= dy;
-    _clampViewScrollY();
+  /// [dx] 水平デルタ, [dy] 垂直デルタ, [localPos] カーソル位置
+  void applyMouseScroll(double dx, double dy, material.Offset localPos) {
+    // 垂直スクロールは常に縦移動に適用
+    if (dy != 0) {
+      _viewScrollY -= dy;
+      _clampViewScrollY();
+    }
+    // 水平スクロールはカーソル下のゾーンに適用
+    if (dx != 0) {
+      final adjustedY = localPos.dy - _effectiveScrollY;
+      final boardRect = material.Rect.fromLTWH(
+          _plyBoardX, _plyFieldY, _plyBoardZoneWidth, _fieldH);
+      final handRect = material.Rect.fromLTWH(
+          10, _plyHandZoneY, size.x - 20, _plyHandZoneH);
+      if (boardRect.contains(material.Offset(localPos.dx, adjustedY))) {
+        _boardScrollX -= dx;
+      } else if (handRect.contains(material.Offset(localPos.dx, adjustedY))) {
+        _handScrollX -= dx;
+      }
+    }
   }
 
   // ─── 空白タップで選択解除 ─────────────────────────────────────

--- a/lib/presentation/components/board_component.dart
+++ b/lib/presentation/components/board_component.dart
@@ -54,7 +54,7 @@ class BoardComponent extends PositionComponent
 
   // ─── コンポーネント管理 ───────────────────────────────────────
 
-  // 手札カード（BoardComponent直下）
+  // 手札カード（_handClipComponent配下、横スクロール）
   final Map<String, CardComponent> _handComponentMap = {};
 
   // ドメインカード（BoardComponent直下）
@@ -68,21 +68,42 @@ class BoardComponent extends PositionComponent
   double _boardScrollX = 0.0;
   bool _dragIsInBoardZone = false;
 
-  // ログ・トリガーキュー（毎フレーム再生成）
-  final List<Component> _logComponents = [];
+  // 手札スクロール用 ClipComponent
+  late ClipComponent _handClipComponent;
+  double _handScrollX = 0.0;
+  bool _dragIsInHandZone = false;
+
+  // 縦スクロール
+  double _viewScrollY = 0.0;
+  static const double _totalContentH = 725.0;
+
+  // トリガーキュー（毎フレーム再生成）
   final List<Component> _triggerQueueComponents = [];
+
+  // 相手エリア表示フラグ（外部から制御）
+  bool opponentAreaVisible = true;
 
   @override
   Future<void> onLoad() async {
     await super.onLoad();
     size = gameRef.size;
 
+    // 縦スクロール初期位置: 画面が小さい場合はプレイヤーHUDが見える位置から開始
+    _viewScrollY = (size.y - _totalContentH).clamp(-double.infinity, 0.0);
+
     // 自分フィールドのボードエリアをクリップする（横スクロール用）
     _boardClipComponent = ClipComponent.rectangle(
-      position: Vector2(_plyBoardX, _plyFieldY),
+      position: Vector2(_plyBoardX, _plyFieldY + _viewScrollY),
       size: Vector2(_plyBoardZoneWidth, _fieldH),
     );
     add(_boardClipComponent);
+
+    // 自分手札エリアをクリップする（横スクロール用）
+    _handClipComponent = ClipComponent.rectangle(
+      position: Vector2(10, _plyHandZoneY + _viewScrollY),
+      size: Vector2(size.x - 20, _plyHandZoneH),
+    );
+    add(_handClipComponent);
   }
 
   // 動的に計算するゾーン幅
@@ -93,9 +114,11 @@ class BoardComponent extends PositionComponent
   @override
   void update(double dt) {
     super.update(dt);
+    // ClipComponent の縦位置を毎フレーム同期
+    _boardClipComponent.position = Vector2(_plyBoardX, _plyFieldY + _viewScrollY);
+    _handClipComponent.position = Vector2(10, _plyHandZoneY + _viewScrollY);
     _updateHand();
     _updateField();
-    _updateLog();
     _updateTriggerQueue();
   }
 
@@ -121,12 +144,14 @@ class BoardComponent extends PositionComponent
     }
 
     // ─── 相手エリア ───────────────────────────────────────────
-    _renderOpponentArea(canvas);
+    if (opponentAreaVisible) {
+      _renderOpponentArea(canvas);
+    }
 
     // ─── セパレーター ─────────────────────────────────────────
     canvas.drawLine(
-      const material.Offset(0, _separatorY),
-      material.Offset(size.x, _separatorY),
+      material.Offset(0, _separatorY + _viewScrollY),
+      material.Offset(size.x, _separatorY + _viewScrollY),
       material.Paint()
         ..color = GameTheme.zoneBorder.withOpacity(0.6)
         ..strokeWidth = 1.5,
@@ -135,13 +160,13 @@ class BoardComponent extends PositionComponent
     // ─── 自分フィールドゾーン ─────────────────────────────────
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(_plyDomainX, _plyFieldY, _domainW, _fieldH),
+      material.Rect.fromLTWH(_plyDomainX, _plyFieldY + _viewScrollY, _domainW, _fieldH),
       GameTheme.domainZoneBg,
       'ドメイン',
     );
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(_plyBoardX, _plyFieldY, _plyBoardZoneWidth, _fieldH),
+      material.Rect.fromLTWH(_plyBoardX, _plyFieldY + _viewScrollY, _plyBoardZoneWidth, _fieldH),
       GameTheme.boardZoneBg,
       'フィールド',
     );
@@ -149,16 +174,13 @@ class BoardComponent extends PositionComponent
     // ─── 自分手札ゾーン ───────────────────────────────────────
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(10, _plyHandZoneY, size.x - 20, _plyHandZoneH),
+      material.Rect.fromLTWH(10, _plyHandZoneY + _viewScrollY, size.x - 20, _plyHandZoneH),
       GameTheme.handZoneBg,
       '手札',
     );
 
     // ─── 自分 HUD ─────────────────────────────────────────────
     _renderPlayerHud(canvas);
-
-    // ─── ログパネル ───────────────────────────────────────────
-    _renderLogPanel(canvas);
 
     super.render(canvas); // 子コンポーネント（カード・ClipComponent）の描画
   }
@@ -167,21 +189,22 @@ class BoardComponent extends PositionComponent
 
   void _renderOpponentArea(material.Canvas canvas) {
     final state = gameRef.gameState;
+    final s = _viewScrollY;
 
     // 相手 HUD（ライフ・手札枚数・デッキ枚数・墓地枚数）
     _renderPill(canvas, '♥ ${state.opponentLife}',
-        const material.Offset(10, _oppHudY), GameTheme.hudLifeColor);
+        material.Offset(10, _oppHudY + s), GameTheme.hudLifeColor);
     _renderPill(canvas, '🂠 ${state.opponentHandCount}',
-        material.Offset(110, _oppHudY), GameTheme.hudDimColor);
+        material.Offset(110, _oppHudY + s), GameTheme.hudDimColor);
     _renderPill(canvas, '📦 40',
-        material.Offset(180, _oppHudY), GameTheme.hudDimColor);
+        material.Offset(180, _oppHudY + s), GameTheme.hudDimColor);
     _renderPill(canvas, '☠ 0',
-        material.Offset(235, _oppHudY), GameTheme.hudDimColor);
+        material.Offset(235, _oppHudY + s), GameTheme.hudDimColor);
 
     // 相手手札ゾーン（裏向きカード）
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(10, _oppHandZoneY, size.x - 20, _oppHandZoneH),
+      material.Rect.fromLTWH(10, _oppHandZoneY + s, size.x - 20, _oppHandZoneH),
       GameTheme.handZoneBg,
       '相手の手札',
     );
@@ -190,13 +213,13 @@ class BoardComponent extends PositionComponent
     // 相手フィールド：ボード（左）・ドメイン（右）— 点対称
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(_oppBoardX, _oppFieldY, _oppBoardZoneWidth, _fieldH),
+      material.Rect.fromLTWH(_oppBoardX, _oppFieldY + s, _oppBoardZoneWidth, _fieldH),
       GameTheme.boardZoneBg,
       '相手のフィールド',
     );
     _renderZone(
       canvas,
-      material.Rect.fromLTWH(_oppDomainX, _oppFieldY, _domainW, _fieldH),
+      material.Rect.fromLTWH(_oppDomainX, _oppFieldY + s, _domainW, _fieldH),
       GameTheme.domainZoneBg,
       '相手のドメイン',
     );
@@ -205,7 +228,7 @@ class BoardComponent extends PositionComponent
   void _renderOpponentHand(material.Canvas canvas, int count) {
     final displayCount = min(count, 7);
     // 右から左に並べる（点対称: 自分の手札は左から右）
-    final cardY = _oppHandZoneY + (_oppHandZoneH - _cardH) / 2;
+    final cardY = _oppHandZoneY + (_oppHandZoneH - _cardH) / 2 + _viewScrollY;
     for (int i = 0; i < displayCount; i++) {
       final cardX = size.x - 15 - _cardW - i * 108.0;
       if (cardX < 15) break;
@@ -247,7 +270,7 @@ class BoardComponent extends PositionComponent
 
   void _renderPlayerHud(material.Canvas canvas) {
     final state = gameRef.gameState;
-    final hudY = _plyHudY;
+    final hudY = _plyHudY + _viewScrollY;
 
     _renderPill(canvas, '♥ ${state.playerLife}',
         material.Offset(10, hudY), GameTheme.hudLifeColor);
@@ -322,15 +345,6 @@ class BoardComponent extends PositionComponent
     painter.paint(canvas, pos);
   }
 
-  void _renderLogPanel(material.Canvas canvas) {
-    final rect =
-        material.Rect.fromLTWH(10, size.y - 200, size.x * 0.6, 190);
-    canvas.drawRRect(
-      material.RRect.fromRectAndRadius(rect, const material.Radius.circular(8)),
-      material.Paint()..color = GameTheme.logPanelBg,
-    );
-  }
-
   // ─── 手札の差分更新 ──────────────────────────────────────────
 
   void _updateHand() {
@@ -342,14 +356,25 @@ class BoardComponent extends PositionComponent
         .where((id) => !currentIds.contains(id))
         .toList()) {
       final comp = _handComponentMap.remove(id);
-      if (comp != null) remove(comp);
+      if (comp != null) _handClipComponent.remove(comp);
     }
 
-    // 手札カードを追加・位置更新（左から右、手札ゾーン中央配置）
-    final cardY = _plyHandZoneY + (_plyHandZoneH - _cardH) / 2;
+    // 手札横スクロールのクランプ
+    if (state.hand.count > 0) {
+      final totalW = 15 + state.hand.count * 112.0 - 12.0;
+      final handZoneW = size.x - 20;
+      final overflow = totalW - handZoneW;
+      final minScroll = overflow > 0 ? -overflow : 0.0;
+      _handScrollX = _handScrollX.clamp(minScroll, 0.0);
+    } else {
+      _handScrollX = 0.0;
+    }
+
+    // 手札カードを追加・位置更新（ClipComponent内ローカル座標）
+    final cardY = (_plyHandZoneH - _cardH) / 2; // clip 内中央
     for (int i = 0; i < state.hand.count; i++) {
       final card = state.hand.cards[i];
-      final targetPos = Vector2(15 + i * 112.0, cardY);
+      final targetPos = Vector2(_handScrollX + 15 + i * 112.0, cardY);
 
       if (_handComponentMap.containsKey(card.instanceId)) {
         _handComponentMap[card.instanceId]!.position = targetPos;
@@ -378,7 +403,7 @@ class BoardComponent extends PositionComponent
           },
         );
         _handComponentMap[card.instanceId] = component;
-        add(component);
+        _handClipComponent.add(component);
       }
     }
   }
@@ -404,7 +429,7 @@ class BoardComponent extends PositionComponent
       // ドメインスロット(plyDomainX, plyFieldY, domainW, fieldH)内に中央配置
       final targetPos = Vector2(
         _plyDomainX + (_domainW - _cardW) / 2,
-        _plyFieldY + (_fieldH - _cardH) / 2,
+        _plyFieldY + (_fieldH - _cardH) / 2 + _viewScrollY,
       );
       if (_domainComponentMap.containsKey(domainCard.instanceId)) {
         _domainComponentMap[domainCard.instanceId]!.position = targetPos;
@@ -482,34 +507,7 @@ class BoardComponent extends PositionComponent
     }
   }
 
-  // ─── ログ・トリガーキュー ─────────────────────────────────────
-
-  void _updateLog() {
-    removeAll(_logComponents);
-    _logComponents.clear();
-
-    final recentLogs = gameRef.gameState.actionLog.reversed
-        .take(9)
-        .toList()
-        .reversed
-        .toList();
-
-    for (int i = 0; i < recentLogs.length; i++) {
-      final isRecent = i == recentLogs.length - 1;
-      final logComponent = TextComponent(
-        text: recentLogs[i],
-        position: Vector2(18, size.y - 190 + i * 19),
-        textRenderer: TextPaint(
-          style: material.TextStyle(
-            color: isRecent ? GameTheme.logTextRecent : GameTheme.logTextOld,
-            fontSize: 11,
-          ),
-        ),
-      );
-      _logComponents.add(logComponent);
-      add(logComponent);
-    }
-  }
+  // ─── トリガーキュー ───────────────────────────────────────────
 
   void _updateTriggerQueue() {
     removeAll(_triggerQueueComponents);
@@ -519,8 +517,8 @@ class BoardComponent extends PositionComponent
     if (queue.isEmpty) return;
 
     final queueTitle = TextComponent(
-      text: 'チェーン:',
-      position: Vector2(size.x - 180, _separatorY + 10),
+      text: 'キュー:',
+      position: Vector2(size.x - 180, _separatorY + _viewScrollY + 10),
       textRenderer: TextPaint(
         style: const material.TextStyle(
           color: material.Colors.orange,
@@ -536,7 +534,7 @@ class BoardComponent extends PositionComponent
       final trigger = queue[i];
       final component = TextComponent(
         text: '${i + 1}. ${trigger.source.card.name}',
-        position: Vector2(size.x - 180, _separatorY + 26 + i * 18),
+        position: Vector2(size.x - 180, _separatorY + _viewScrollY + 26 + i * 18),
         textRenderer: TextPaint(
           style: const material.TextStyle(
             color: material.Colors.white70,
@@ -549,22 +547,35 @@ class BoardComponent extends PositionComponent
     }
   }
 
-  // ─── ドラッグ（ボード横スクロール） ──────────────────────────
+  // ─── ドラッグ（縦スクロール・手札横スクロール・ボード横スクロール） ─
 
   @override
   void onDragStart(DragStartEvent event) {
     super.onDragStart(event);
     final pos = event.localPosition;
+    // スクロール補正後のY座標でヒットテスト
+    final adjustedY = pos.y - _viewScrollY;
     final boardRect = material.Rect.fromLTWH(
         _plyBoardX, _plyFieldY, _plyBoardZoneWidth, _fieldH);
+    final handRect = material.Rect.fromLTWH(
+        10, _plyHandZoneY, size.x - 20, _plyHandZoneH);
     _dragIsInBoardZone =
-        boardRect.contains(material.Offset(pos.x, pos.y));
+        boardRect.contains(material.Offset(pos.x, adjustedY));
+    _dragIsInHandZone =
+        handRect.contains(material.Offset(pos.x, adjustedY));
   }
 
   @override
   void onDragUpdate(DragUpdateEvent event) {
     if (_dragIsInBoardZone) {
       _boardScrollX += event.localDelta.x;
+    } else if (_dragIsInHandZone) {
+      _handScrollX += event.localDelta.x;
+    } else {
+      // 縦スクロール
+      _viewScrollY += event.localDelta.y;
+      final minScrollY = (size.y - _totalContentH).clamp(-double.infinity, 0.0);
+      _viewScrollY = _viewScrollY.clamp(minScrollY, 0.0);
     }
   }
 
@@ -572,6 +583,7 @@ class BoardComponent extends PositionComponent
   void onDragEnd(DragEndEvent event) {
     super.onDragEnd(event);
     _dragIsInBoardZone = false;
+    _dragIsInHandZone = false;
   }
 
   // ─── 空白タップで選択解除 ─────────────────────────────────────

--- a/lib/presentation/components/board_component.dart
+++ b/lib/presentation/components/board_component.dart
@@ -76,12 +76,30 @@ class BoardComponent extends PositionComponent
   // 縦スクロール
   double _viewScrollY = 0.0;
   static const double _totalContentH = 725.0;
+  // 相手エリアの高さ（非表示時にビューをシフトする量）
+  static const double _opponentAreaH = _separatorY; // 360.0
 
   // トリガーキュー（毎フレーム再生成）
   final List<Component> _triggerQueueComponents = [];
 
-  // 相手エリア表示フラグ（外部から制御）
-  bool opponentAreaVisible = true;
+  // 相手エリア表示フラグ（外部から setter で制御）
+  bool _opponentAreaVisible = true;
+  bool get opponentAreaVisible => _opponentAreaVisible;
+  set opponentAreaVisible(bool value) {
+    if (_opponentAreaVisible == value) return;
+    _opponentAreaVisible = value;
+    // 非表示にしたら相手エリア分だけ上にシフト、表示に戻したら元に戻す
+    _viewScrollY += value ? _opponentAreaH : -_opponentAreaH;
+    _clampViewScrollY();
+  }
+
+  void _clampViewScrollY() {
+    final effectiveH = _opponentAreaVisible
+        ? _totalContentH
+        : _totalContentH - _opponentAreaH;
+    final minScrollY = (size.y - effectiveH).clamp(-double.infinity, 0.0);
+    _viewScrollY = _viewScrollY.clamp(minScrollY, 0.0);
+  }
 
   @override
   Future<void> onLoad() async {
@@ -90,6 +108,7 @@ class BoardComponent extends PositionComponent
 
     // 縦スクロール初期位置: 画面が小さい場合はプレイヤーHUDが見える位置から開始
     _viewScrollY = (size.y - _totalContentH).clamp(-double.infinity, 0.0);
+    _clampViewScrollY();
 
     // 自分フィールドのボードエリアをクリップする（横スクロール用）
     _boardClipComponent = ClipComponent.rectangle(
@@ -574,8 +593,7 @@ class BoardComponent extends PositionComponent
     } else {
       // 縦スクロール
       _viewScrollY += event.localDelta.y;
-      final minScrollY = (size.y - _totalContentH).clamp(-double.infinity, 0.0);
-      _viewScrollY = _viewScrollY.clamp(minScrollY, 0.0);
+      _clampViewScrollY();
     }
   }
 

--- a/lib/presentation/components/board_component.dart
+++ b/lib/presentation/components/board_component.dart
@@ -131,6 +131,17 @@ class BoardComponent extends PositionComponent
   double get _oppDomainX => size.x - 10 - _domainW;
 
   @override
+  void onGameResize(Vector2 size) {
+    super.onGameResize(size);
+    this.size = size;
+    // ClipComponent のサイズを新しい画面幅に合わせて更新
+    _boardClipComponent.size = Vector2(_plyBoardZoneWidth, _fieldH);
+    _handClipComponent.size = Vector2(size.x - 20, _plyHandZoneH);
+    // スクロール範囲を再クランプ
+    _clampViewScrollY();
+  }
+
+  @override
   void update(double dt) {
     super.update(dt);
     // ClipComponent の縦位置を毎フレーム同期
@@ -602,6 +613,13 @@ class BoardComponent extends PositionComponent
     super.onDragEnd(event);
     _dragIsInBoardZone = false;
     _dragIsInHandZone = false;
+  }
+
+  // ─── マウスホイール（Flutter Listener から呼び出し） ─────────
+
+  void applyMouseScroll(double dy) {
+    _viewScrollY -= dy;
+    _clampViewScrollY();
   }
 
   // ─── 空白タップで選択解除 ─────────────────────────────────────

--- a/lib/presentation/game/tcg_game.dart
+++ b/lib/presentation/game/tcg_game.dart
@@ -34,6 +34,9 @@ class TCGGame extends FlameGame {
 
   TCGGame({this.initialDeck});
 
+  /// ゲームボードコンポーネントへの参照（外部からトグル操作などに使用）
+  BoardComponent? boardComponent;
+
   @override
   Future<void> onLoad() async {
     super.onLoad();
@@ -42,7 +45,8 @@ class TCGGame extends FlameGame {
     await _initializeGame();
 
     // ゲームボードのUIコンポーネントをゲームに追加
-    add(BoardComponent());
+    boardComponent = BoardComponent();
+    add(boardComponent!);
   }
 
   /// ゲームの初期設定（デッキのロード、シャッフル、ドロー）を行います。

--- a/lib/presentation/game/tcg_game.dart
+++ b/lib/presentation/game/tcg_game.dart
@@ -122,7 +122,7 @@ class TCGGame extends FlameGame {
     }
 
     // ログを追加
-    gameState.actionLog.addAll(result.logs);
+    gameState.addAllToLog(result.logs);
 
     // UI更新のためのダミーコールバック。将来的にはイベントバスなどで置き換えるべき。
     Map<dynamic, dynamic> dummyUpdate() => {};
@@ -130,7 +130,7 @@ class TCGGame extends FlameGame {
     // トリガーサービスを呼び出して、発生したすべてのトリガーを解決
     final resolveResult =
         await TriggerService.resolveAll(gameState, dummyUpdate);
-    gameState.actionLog.addAll(resolveResult.logs);
+    gameState.addAllToLog(resolveResult.logs);
 
     if (!resolveResult.success) {
       gameState.addToLog('Trigger resolution failed: ${resolveResult.error}');
@@ -212,7 +212,7 @@ class TCGGame extends FlameGame {
     for (int i = 0; i < pendingEffects.length; i++) {
       final effect = pendingEffects[i];
       final result = OperationExecutor.executeOperation(gameState, effect);
-      gameState.actionLog.addAll(result.logs);
+      gameState.addAllToLog(result.logs);
 
       if (result.awaitingChoice) {
         // さらに選択が必要 → 残り effect を新しい choiceRequest に付与して中断
@@ -241,7 +241,7 @@ class TCGGame extends FlameGame {
     // 全 effect 完了 → トリガーキューの残りを再開
     if (gameState.choiceRequest.value == null) {
       final resolveResult = await TriggerService.resolveAll(gameState, dummyUpdate);
-      gameState.actionLog.addAll(resolveResult.logs);
+      gameState.addAllToLog(resolveResult.logs);
     }
   }
 
@@ -302,7 +302,7 @@ class TCGGame extends FlameGame {
     // トリガーサービスを呼び出して、発生したすべてのトリガーを解決
     final resolveResult =
         await TriggerService.resolveAll(gameState, dummyUpdate);
-    gameState.actionLog.addAll(resolveResult.logs);
+    gameState.addAllToLog(resolveResult.logs);
 
     if (!resolveResult.success) {
       gameState.addToLog('トリガー解決に失敗しました: ${resolveResult.error}');

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flame/game.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import '../../domain/models/card_selection_state.dart';
 import '../../domain/models/choice_request.dart';
 import '../../domain/models/deck.dart';
-import '../../presentation/components/board_component.dart';
 import '../../presentation/game/tcg_game.dart';
 import '../widgets/card_detail_panel.dart';
 import '../widgets/choice_overlay.dart';
@@ -37,9 +37,8 @@ class _GameScreenState extends State<GameScreen> {
   void _toggleOpponentArea() {
     setState(() {
       _opponentAreaVisible = !_opponentAreaVisible;
-      // BoardComponent に反映
-      final board = _game.children.whereType<BoardComponent>().firstOrNull;
-      if (board != null) board.opponentAreaVisible = _opponentAreaVisible;
+      // TCGGame が保持する boardComponent に直接反映
+      _game.boardComponent?.opponentAreaVisible = _opponentAreaVisible;
     });
   }
 
@@ -62,30 +61,37 @@ class _GameScreenState extends State<GameScreen> {
       backgroundColor: const Color(0xFF0D1117),
       body: Stack(
         children: [
-          GameWidget(
-            game: _game,
-            loadingBuilder: (context) => const Center(
-              child: CircularProgressIndicator(
-                color: Color(0xFFFFD700),
-              ),
-            ),
-            errorBuilder: (context, error) => Center(
-              child: Text(
-                'エラーが発生しました: $error',
-                style: const TextStyle(color: Colors.red),
-              ),
-            ),
-            overlayBuilderMap: {
-              'pause': (context, TCGGame game) => Center(
-                child: Container(
-                  color: Colors.black54,
-                  child: const Text(
-                    '一時停止中',
-                    style: TextStyle(color: Colors.white, fontSize: 24),
-                  ),
+          Listener(
+            onPointerSignal: (event) {
+              if (event is PointerScrollEvent) {
+                _game.boardComponent?.applyMouseScroll(event.scrollDelta.dy);
+              }
+            },
+            child: GameWidget(
+              game: _game,
+              loadingBuilder: (context) => const Center(
+                child: CircularProgressIndicator(
+                  color: Color(0xFFFFD700),
                 ),
               ),
-            },
+              errorBuilder: (context, error) => Center(
+                child: Text(
+                  'エラーが発生しました: $error',
+                  style: const TextStyle(color: Colors.red),
+                ),
+              ),
+              overlayBuilderMap: {
+                'pause': (context, TCGGame game) => Center(
+                  child: Container(
+                    color: Colors.black54,
+                    child: const Text(
+                      '一時停止中',
+                      style: TextStyle(color: Colors.white, fontSize: 24),
+                    ),
+                  ),
+                ),
+              },
+            ),
           ),
           // カード選択オーバーレイ（ChoiceRequest 発生時に表示）
           ValueListenableBuilder<ChoiceRequest?>(

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 import '../../domain/models/card_selection_state.dart';
 import '../../domain/models/choice_request.dart';
 import '../../domain/models/deck.dart';
+import '../../presentation/components/board_component.dart';
 import '../../presentation/game/tcg_game.dart';
 import '../widgets/card_detail_panel.dart';
 import '../widgets/choice_overlay.dart';
+import '../widgets/log_panel.dart';
 
 /// ゲームプレイ画面
 ///
@@ -23,11 +25,21 @@ class GameScreen extends StatefulWidget {
 
 class _GameScreenState extends State<GameScreen> {
   late final TCGGame _game;
+  bool _opponentAreaVisible = true;
 
   @override
   void initState() {
     super.initState();
     _game = TCGGame(initialDeck: widget.deck);
+  }
+
+  void _toggleOpponentArea() {
+    setState(() {
+      _opponentAreaVisible = !_opponentAreaVisible;
+      // BoardComponent に反映
+      final board = _game.children.whereType<BoardComponent>().firstOrNull;
+      if (board != null) board.opponentAreaVisible = _opponentAreaVisible;
+    });
   }
 
   void _handleConfirm(CardSelectionState sel) {
@@ -84,6 +96,35 @@ class _GameScreenState extends State<GameScreen> {
                 onConfirm: (selected) => _game.resolveChoice(selected),
               );
             },
+          ),
+          // ログパネル（画面左下固定・カードと重ならない）
+          Positioned(
+            left: 0,
+            bottom: 8,
+            child: ValueListenableBuilder<List<String>>(
+              valueListenable: _game.gameState.actionLogNotifier,
+              builder: (context, logs, _) => LogPanel(logs: logs),
+            ),
+          ),
+          // 相手エリアトグルボタン（右上固定）
+          Positioned(
+            top: 8,
+            right: 8,
+            child: SafeArea(
+              child: IconButton(
+                icon: Icon(
+                  _opponentAreaVisible
+                      ? Icons.visibility
+                      : Icons.visibility_off,
+                  color: Colors.white54,
+                  size: 20,
+                ),
+                tooltip: _opponentAreaVisible ? '相手エリアを隠す' : '相手エリアを表示',
+                onPressed: _toggleOpponentArea,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+            ),
           ),
           // カード詳細パネル（選択時にスライドイン）
           Positioned(

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -64,7 +64,11 @@ class _GameScreenState extends State<GameScreen> {
           Listener(
             onPointerSignal: (event) {
               if (event is PointerScrollEvent) {
-                _game.boardComponent?.applyMouseScroll(event.scrollDelta.dy);
+                _game.boardComponent?.applyMouseScroll(
+                  event.scrollDelta.dx,
+                  event.scrollDelta.dy,
+                  event.localPosition,
+                );
               }
             },
             child: GameWidget(

--- a/lib/ui/widgets/log_panel.dart
+++ b/lib/ui/widgets/log_panel.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import '../theme/game_theme.dart';
+
+/// ゲームログを表示する Flutter ウィジェット。
+///
+/// Flame キャンバスではなく Flutter レイヤーで描画することで、
+/// カードや手札ゾーンとの重なりを防ぐ。
+class LogPanel extends StatelessWidget {
+  final List<String> logs;
+
+  const LogPanel({super.key, required this.logs});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final panelWidth = screenWidth * 0.6;
+    final recentLogs = logs.length > 9 ? logs.sublist(logs.length - 9) : logs;
+
+    return Container(
+      width: panelWidth,
+      margin: const EdgeInsets.only(left: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: GameTheme.logPanelBg,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (int i = 0; i < recentLogs.length; i++)
+            Text(
+              recentLogs[i],
+              style: TextStyle(
+                color: i == recentLogs.length - 1
+                    ? GameTheme.logTextRecent
+                    : GameTheme.logTextOld,
+                fontSize: 11,
+                height: 1.5,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Changes

- **Vertical scrolling**: Added support for smooth vertical scrolling on mobile devices to view opponent and player areas
- **Hand card scrolling**: Implemented horizontal scrolling for hand cards with proper clipping
- **Log panel migration**: Moved action log display from Flame canvas to Flutter widget layer to prevent overlapping with cards
- **Queue label fix**: Changed "チェーン" (Chain) to "キュー" (Queue) for trigger queue display
- **Opponent area toggle**: Added visibility toggle button (eye icon) to show/hide opponent area on small screens
- **GameState improvements**: 
  - Converted `actionLog` to `ValueNotifier<List<String>>` for reactive updates
  - Added `addAllToLog()` method for batch log entries
- **Board component refactor**: 
  - Removed canvas-based log rendering
  - Updated all rendering positions to account for scroll offset
  - Improved drag detection with scroll-adjusted coordinates