### PR TITLE
Add game over overlay with win/loss animations

### DIFF
--- a/lib/presentation/game/tcg_game.dart
+++ b/lib/presentation/game/tcg_game.dart
@@ -47,19 +47,18 @@ class TCGGame extends FlameGame {
 
   /// ゲームの初期設定（デッキのロード、シャッフル、ドロー）を行います。
   Future<void> _initializeGame() async {
-    List<CardData> cards = [];
+    if (initialDeck == null) {
+      gameState.addToLog('Error: No deck specified. Please select a deck.');
+      return;
+    }
 
-    if (initialDeck != null) {
-      // 指定されたデッキからカードを読み込む
-      for (final cardId in initialDeck!.cardIds) {
-        final card = await CardRepository.loadCard(cardId);
-        if (card != null) {
-          cards.add(card);
-        }
+    // 指定されたデッキからカードを読み込む
+    final List<CardData> cards = [];
+    for (final cardId in initialDeck!.cardIds) {
+      final card = await CardRepository.loadCard(cardId);
+      if (card != null) {
+        cards.add(card);
       }
-    } else {
-      // デッキが指定されていない場合は全カードを読み込む（デバッグ用など）
-      cards = await CardRepository.loadAllCards();
     }
 
     if (cards.isEmpty) {

--- a/lib/ui/screens/game_screen.dart
+++ b/lib/ui/screens/game_screen.dart
@@ -5,6 +5,7 @@ import '../../domain/models/card_selection_state.dart';
 import '../../domain/models/choice_request.dart';
 import '../../domain/models/deck.dart';
 import '../../presentation/game/tcg_game.dart';
+import '../../routes.dart';
 import '../widgets/card_detail_panel.dart';
 import '../widgets/choice_overlay.dart';
 import '../widgets/game_over_overlay.dart';
@@ -29,6 +30,16 @@ class _GameScreenState extends State<GameScreen> {
   void initState() {
     super.initState();
     _game = TCGGame(initialDeck: widget.deck);
+    if (widget.deck == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          Navigator.of(context).pushReplacementNamed(
+            AppRoutes.deckSelector,
+            arguments: true,
+          );
+        }
+      });
+    }
   }
 
   void _handleConfirm(CardSelectionState sel) {


### PR DESCRIPTION
## Changes

- **Core**: Added `gameOverNotifier` ValueNotifier to `GameState` to track game completion status (null=playing, true=win, false=loss)
- **Domain**: Updated `OperationExecutor` to notify `gameOverNotifier` when `_executeWin`, `_executeWinIf`, or `_executeLoseIf` are triggered
- **UI**: Created new `GameOverOverlay` widget with distinct animations:
  - **Victory**: Gold gradient text with scale-in animation and glow effect
  - **Defeat**: Red text with fade-in animation
- **Screen**: Integrated `GameOverOverlay` into `GameScreen` using `ValueListenableBuilder` and added deck validation
- **Flame**: Fixed `TCGGame._initializeGame()` to prevent loading all cards when deck is not specified
- **Docs**: Documented design decision in audit log

## Impact

Provides clear visual feedback when game ends, improving player experience. Players now see an overlay prompting them to return to menu after win/loss.